### PR TITLE
Add Dockerfile for mybinder.org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# Dockerfile for mybinder.org
+# 
+# You can build a Docker image locally using
+# >>> docker build --rm -t cfspopcon .
+# 
+# To start the docker image and launch a Jupyter notebook, use
+# >>> docker run -it -p 8888:8888 -t cfspopcon
+# 
+# To start the docker image with a bash shell, use
+# >>> docker run --entrypoint /bin/bash -it -p 8888:8888 -t cfspopcon
+
+# 1. Start by using a base image from
+# https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#jupyter-scipy-notebook
+# 
+# N.b. for mybinder.org, we need to pin to a specific tag
+FROM jupyter/scipy-notebook:848a82674792
+
+# 2. Install a fortran compiler into this image, so that we
+# can compile the radas headers
+RUN conda install -c conda-forge gfortran -y
+# 3. Install poetry, which is what we use to build cfspopcon
+RUN pip install poetry
+
+# 4. Copy in the files from the local directory
+COPY --chown=$NB_USER:$NB_GID . ./
+
+# 5. Tell poetry to install in the global python environment,
+# so we don't have to worry about custom kernels or venvs.
+RUN poetry config virtualenvs.create false
+# 6. Install cfspopcon in the global python environment.
+RUN poetry install
+
+# 7. Download the radas project
+RUN git clone https://github.com/cfs-energy/radas.git
+# 8. Download atomic data files from OpenADAS
+RUN PYTHONPATH=radas python radas/adas_data/fetch_adas_data.py
+# 9. Run radas to compute Lz and <Z> curves from the atomic data
+RUN PYTHONPATH=radas python radas/run_radas.py
+
+# 10. Copy the results from radas into cfspopcon
+RUN cp radas/cases/*/output/*.nc cfspopcon/atomic_data

--- a/README.md
+++ b/README.md
@@ -4,5 +4,6 @@ cfspopcon: 0D Plasma Calculations & Plasma OPerating CONtours
 [![Build Status](https://github.com/cfs-energy/cfspopcon/actions/workflows/workflow_actions.yml/badge.svg)](https://github.com/cfs-energy/cfspopcon/actions)
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 [![Documentation Status](https://readthedocs.org/projects/cfspopcon/badge/?version=latest)](https://cfspopcon.readthedocs.io/en/latest/?badge=latest)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/cfs-energy/cfspopcon/HEAD)
 
 For more information please have a look at our [documentation](https://cfspopcon.readthedocs.io/en/latest/).


### PR DESCRIPTION
Adds a Dockerfile which can be used by mybinder.org.

This Dockerfile installs the project using poetry and also fetches the ADAS data.

This merge request also adds a badge to the readme [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/cfs-energy/cfspopcon/HEAD).

This badge **will not work** until this merge request is merged into main. To test out the Docker install, you can use [https://mybinder.org/v2/gh/tbody-cfs/cfspopcon/mybinder](https://mybinder.org/v2/gh/tbody-cfs/cfspopcon/mybinder?labpath=docs%2Fdoc_sources%2Fgetting_started.ipynb)

Although this merge request is intended for use with mybinder.org, it does also enable building and running Docker images locally. Instructions for this are given in the Dockerfile

