### PR TITLE
fix: disable pint cache to avoid cache problems, see pint#1572

### DIFF
--- a/cfspopcon/unit_handling/setup_unit_handling.py
+++ b/cfspopcon/unit_handling/setup_unit_handling.py
@@ -15,7 +15,6 @@ from typing_extensions import ParamSpec
 ureg = pint_xarray.setup_registry(
     pint.UnitRegistry(
         force_ndarray_like=True,
-        cache_folder=":auto:",
     )
 )
 


### PR DESCRIPTION
Registry creation takes about 200ms on my machine. 
I don't think that delay is worth the headache the cache creates for users when something goes wrong. So until it's more robust, I'd prefer to disable it. 

cc: @tbody-cfs @AudreySaltzman