### PR TITLE
feat(ci): add testing for regression result generation

### DIFF
--- a/.github/workflows/workflow_actions.yml
+++ b/.github/workflows/workflow_actions.yml
@@ -90,6 +90,11 @@ jobs:
       - name: Tests
         run: MPLBACKEND=Agg poetry run pytest tests --nbmake example_cases
 
+      - name: Tests with new regression results
+        run: |
+          poetry run python tests/regression_results/generate_regression_results.py
+          MPLBACKEND=Agg poetry run pytest --no-cov tests/test_regression_against_cases.py
+
       - name: Test package
         run: |
           poetry build -f wheel


### PR DESCRIPTION
Adds a test that first generates new references for the regression tests and then reruns the regression test cases against them. 

Motivated by #10 but still not able to reproduce the described problem locally nor in the CI