### PR TITLE
fix(doc): remove incorrect --with flag in install command

### DIFF
--- a/docs/doc_sources/Usage.rst
+++ b/docs/doc_sources/Usage.rst
@@ -10,7 +10,7 @@ The cfspopcon package is available on the `Python Package Index <https://pypi.or
 
 .. code::
 
-  >>> pip install cfspopcon --with dev
+  >>> pip install cfspopcon
   >>> radas -d ./radas_dir
 
 The second step is to generate a folder of OpenADAS atomic data files. We can't ship these files with


### PR DESCRIPTION
The installation instructions incorrectly pass a `--with dev` to the `pip install cfspopcon`.

While poetry has a `--with` flag, `pip` doesn't have a `--with` flag. And `poetry` dev dependencies aren't something one can install via a `pip` command, so just removing this.

I've tested that just a simple
```
pip install cfspopcon
radas -d ./radas_dir
```

still works.