### PR TITLE
Allow for extensible default_units

### DIFF
--- a/cfspopcon/unit_handling/__init__.py
+++ b/cfspopcon/unit_handling/__init__.py
@@ -6,7 +6,7 @@ import xarray as xr
 from pint import DimensionalityError, UndefinedUnitError, UnitStrippedWarning
 
 from .decorator import wraps_ufunc
-from .default_units import convert_to_default_units, default_unit, magnitude_in_default_units, set_default_units
+from .default_units import DefaultUnits, convert_to_default_units, magnitude_in_default_units, set_default_units
 from .setup_unit_handling import (
     Quantity,
     Unit,
@@ -29,7 +29,7 @@ __all__ = [
     "magnitude_in_default_units",
     "magnitude_in_units",
     "set_default_units",
-    "default_unit",
+    "DefaultUnits",
     "convert_to_default_units",
     "convert_units",
     "magnitude",

--- a/cfspopcon/unit_handling/default_units.py
+++ b/cfspopcon/unit_handling/default_units.py
@@ -30,7 +30,6 @@ class DefaultUnits:
         Returns: Unit
         """
         if len(cls.unit_dictionary) == 0:
-            print("Reading defaults")
             # If the unit_dictionary dictionary is empty, read units from the default file.
             cls.read_units_from_file()
 

--- a/docs/doc_sources/getting_started.ipynb
+++ b/docs/doc_sources/getting_started.ipynb
@@ -65,7 +65,7 @@
     "2. The `points` entry is stored in a separate dictionary. This gives a set of key-value pairs of 'optimal' points (for instance, giving the point with the maximum fusion power gain).\n",
     "3. The `grids` entry is converted into an `xr.DataArray` storing a `np.linspace` or `np.logspace` of values which we scan over. We usually scan over `average_electron_density` and `average_electron_temp`, but there's nothing preventing you from scanning over other numerical input variables or having more than 2 dimensions which you scan over (n.b. this can get expensive!).\n",
     "4. Each input variable is checked to see if its name matches one of the enumerators in `cfspopcon.named_options`. These are used to store switch values, such as `cfspopcon.named_options.ReactionType.DT` which indicates that we're interested in the DT fusion reaction.\n",
-    "5. Each input variable is converted into its default units, stored in `cfspopcon.unit_handling.default_units.DEFAULT_UNITS`. This will set, for instance, the `average_electron_temp` values to have units of `keV`."
+    "5. Each input variable is converted into its default units, stored in `cfspopcon.unit_handling.default_units.DefaultUnits`. This will set, for instance, the `average_electron_temp` values to have units of `keV`."
    ]
   },
   {
@@ -2663,7 +2663,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/tests/test_unit_handling/test_default_units.py
+++ b/tests/test_unit_handling/test_default_units.py
@@ -1,19 +1,19 @@
 import pytest
 from cfspopcon.unit_handling import ureg, UndefinedUnitError
-from cfspopcon.unit_handling.default_units import read_default_units, check_units_are_valid
+from cfspopcon.unit_handling.default_units import DefaultUnits
 
 
 def test_read_default_units():
     """Make sure that the default units can be read without error."""
-    read_default_units()
+    DefaultUnits.read_units_from_file()
 
 
 def test_check_units_are_valid():
     valid_dict = dict(value="metres", value2="kg", value3=ureg.eV, value4=ureg.n19)
 
-    check_units_are_valid(valid_dict)
+    DefaultUnits.check_units_are_valid(valid_dict)
 
     invalid_dict = dict(value4=ureg.n19, value="ducks", value2="chickens", value3=ureg.eV)
 
     with pytest.raises(UndefinedUnitError):
-        check_units_are_valid(invalid_dict)
+        DefaultUnits.check_units_are_valid(invalid_dict)


### PR DESCRIPTION
This PR makes it possible to append to or replace the `default_units.yaml` file in a project that is using `cfsPOPCON` as a library.

This lets me do the following.
```
from pathlib import Path
from cfspopcon.algorithm_class import Algorithm
from cfspopcon.unit_handling import DefaultUnits, convert_units, ureg
import numpy as np

Algorithm.instances = {}
DefaultUnits.read_units_from_file(Path("module") / "default_units.yaml")

@Algorithm.register_algorithm(return_keys=["parallel_to_perp_factor"])
def calc_parallel_to_perp_factor(angle_of_incidence):
    """Calculate the projection of parallel quantities into perpendicular-to-target quantities.
    
    i.e. q_perp = parallel_to_perp_factor * q_parallel
    """
    return np.sin(convert_units(angle_of_incidence, ureg.radian))

Algorithm.get_algorithm("calc_parallel_to_perp_factor").run(angle_of_incidence = 1.0 * ureg.degree)
```