### PR TITLE
refactor(test): ensure pytest turns warnings into errors

### DIFF
--- a/cfspopcon/unit_handling/default_units.py
+++ b/cfspopcon/unit_handling/default_units.py
@@ -26,7 +26,7 @@ def check_units_are_valid(units_dictionary: dict[str, str]) -> None:
     if invalid_units:
         msg = "The following units are not recognized:\n"
         msg += "\n".join([f"{key}: {units}" for key, units in invalid_units])
-        raise ValueError(msg)  # type:ignore[arg-type]
+        raise ValueError(msg)
 
 
 def read_default_units_from_file(filepath: Optional[Path] = None) -> None:

--- a/cfspopcon/unit_handling/default_units.py
+++ b/cfspopcon/unit_handling/default_units.py
@@ -17,14 +17,16 @@ from .setup_unit_handling import Quantity, convert_units, magnitude_in_units
 def check_units_are_valid(units_dictionary: dict[str, str]) -> None:
     """Ensure that all units in units_dictionary are valid."""
     invalid_units = []
-    for units in units_dictionary.values():
+    for key, units in units_dictionary.items():
         try:
             Quantity(1.0, units)
         except UndefinedUnitError:  # noqa: PERF203
-            invalid_units.append(units)
+            invalid_units.append((key, units))
 
     if invalid_units:
-        raise UndefinedUnitError(invalid_units)  # type:ignore[arg-type]
+        msg = "The following units are not recognized:\n"
+        msg += "\n".join([f"{key}: {units}" for key, units in invalid_units])
+        raise ValueError(msg)  # type:ignore[arg-type]
 
 
 def read_default_units_from_file(filepath: Optional[Path] = None) -> None:

--- a/cfspopcon/unit_handling/default_units.py
+++ b/cfspopcon/unit_handling/default_units.py
@@ -5,7 +5,6 @@ from importlib.resources import as_file, files
 from numbers import Number
 from pathlib import Path
 from typing import Any, Optional, Union, overload
-from warnings import warn
 
 import numpy as np
 import xarray as xr
@@ -18,11 +17,10 @@ from .setup_unit_handling import Quantity, convert_units, magnitude_in_units
 def check_units_are_valid(units_dictionary: dict[str, str]) -> None:
     """Ensure that all units in units_dictionary are valid."""
     invalid_units = []
-    for key, units in units_dictionary.items():
+    for units in units_dictionary.values():
         try:
             Quantity(1.0, units)
         except UndefinedUnitError:  # noqa: PERF203
-            warn(f"Undefined units '{units}' for '{key}", stacklevel=3)
             invalid_units.append(units)
 
     if invalid_units:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,10 @@ markers = [
     "cli: marks tests as testing the command-line-interface (deselect with '-m \"not cli\"')",
     "regression: marks tests as checking the regression result (deselect with '-m \"not regression\"')",
 ]
+filterwarnings = [
+  "error",
+  "ignore:numpy.ndarray size changed, may indicate binary incompatibility. Expected 16 from C header, got 96 from PyObject"
+]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/test_unit_handling/test_default_units.py
+++ b/tests/test_unit_handling/test_default_units.py
@@ -8,7 +8,6 @@ def test_read_default_units():
     read_default_units_from_file()
 
 
-@pytest.mark.filterwarnings("ignore:Undefined units")
 def test_check_units_are_valid():
     valid_dict = dict(value="metres", value2="kg", value3=ureg.eV, value4=ureg.n19)
 

--- a/tests/test_unit_handling/test_default_units.py
+++ b/tests/test_unit_handling/test_default_units.py
@@ -15,5 +15,5 @@ def test_check_units_are_valid():
 
     invalid_dict = dict(value4=ureg.n19, value="ducks", value2="chickens", value3=ureg.eV)
 
-    with pytest.raises(UndefinedUnitError):
+    with pytest.raises(ValueError, match="The following units are not recognized.*"):
         check_units_are_valid(invalid_dict)


### PR DESCRIPTION
Adds 
```
filterwarnings = [
  "error",
  "ignore:numpy.ndarray size changed, may indicate binary incompatibility. Expected 16 from C header, got 96 from PyObject"
]
``` 
to our `pyproject.toml`.

The first is to turn all warnings into errors.
Line 2 is to ignore the numpy compatibility warnings that `netcdf4` generates.

