### PR TITLE
feat(ci): add a stale issues/pr bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,33 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    # Everyday 6:30 am
+  - cron: "30 6 * * *"
+
+jobs:
+  stale_bot:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+    - uses: actions/stale@v9
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        # We skip issues with these labels
+        exempt-issue-labels: "bug,enhancement"
+        stale-issue-message: >
+            This issue has not seen any activity in the past 60 days.
+            It is now marked as stale and will be closed in 7 days if
+            no further activity is registered.
+        # We skip PRs with these labels
+        exempt-pr-labels: 'WIP,blocked'
+        stale-pr-message: >
+            This PR has not seen any activity in the past 60 days.
+            It is now marked as stale and will be closed in 7 days if
+            no further activity is registered.
+        stale-issue-label: 'no-issue-activity'
+        stale-pr-label: 'no-pr-activity'
+        days-before-stale: 60
+        days-before-close: 7


### PR DESCRIPTION
A bot that will mark issues and PRs as stale after 60 days of inactivity and post a message that these will be closed in 7 days if no further activity is registered.

This behaviour doesn't apply to issues marked as `enhancement` or `bug`.
PRs that are marked `WIP` or `blocked` are also skipped by the bot.

