### PR TITLE
Add deuterium, tritium and boron species (compatibility with cfs-energy/radas#18)

### DIFF
--- a/cfspopcon/formulas/impurities/impurity_charge_state.py
+++ b/cfspopcon/formulas/impurities/impurity_charge_state.py
@@ -68,24 +68,8 @@ def _calc_impurity_charge_state(
     interpolator = atomic_data.coronal_Z_interpolators[impurity_species]
     interpolated_values = np.power(10, interpolator((np.log10(average_electron_temp), np.log10(average_electron_density))))
 
-    atomic_number = {
-        AtomicSpecies.Hydrogen: 1,
-        AtomicSpecies.Deuterium: 1,
-        AtomicSpecies.Tritium: 1,
-        AtomicSpecies.Helium: 2,
-        AtomicSpecies.Lithium: 3,
-        AtomicSpecies.Beryllium: 4,
-        AtomicSpecies.Boron: 5,
-        AtomicSpecies.Carbon: 6,
-        AtomicSpecies.Nitrogen: 7,
-        AtomicSpecies.Oxygen: 8,
-        AtomicSpecies.Neon: 10,
-        AtomicSpecies.Argon: 18,
-        AtomicSpecies.Krypton: 36,
-        AtomicSpecies.Xenon: 54,
-        AtomicSpecies.Tungsten: 74,
-    }
+    atomic_number = atomic_data.datasets[impurity_species].atomic_number
 
-    interpolated_values = np.minimum(interpolated_values, atomic_number[impurity_species])
+    interpolated_values = np.minimum(interpolated_values, atomic_number)
     interpolated_values = np.maximum(interpolated_values, 0)
     return interpolated_values  # type:ignore[no-any-return]

--- a/cfspopcon/formulas/impurities/impurity_charge_state.py
+++ b/cfspopcon/formulas/impurities/impurity_charge_state.py
@@ -68,6 +68,24 @@ def _calc_impurity_charge_state(
     interpolator = atomic_data.coronal_Z_interpolators[impurity_species]
     interpolated_values = np.power(10, interpolator((np.log10(average_electron_temp), np.log10(average_electron_density))))
 
-    interpolated_values = np.minimum(interpolated_values, impurity_species.value)
+    atomic_number = {
+        AtomicSpecies.Hydrogen: 1,
+        AtomicSpecies.Deuterium: 1,
+        AtomicSpecies.Tritium: 1,
+        AtomicSpecies.Helium: 2,
+        AtomicSpecies.Lithium: 3,
+        AtomicSpecies.Beryllium: 4,
+        AtomicSpecies.Boron: 5,
+        AtomicSpecies.Carbon: 6,
+        AtomicSpecies.Nitrogen: 7,
+        AtomicSpecies.Oxygen: 8,
+        AtomicSpecies.Neon: 10,
+        AtomicSpecies.Argon: 18,
+        AtomicSpecies.Krypton: 36,
+        AtomicSpecies.Xenon: 54,
+        AtomicSpecies.Tungsten: 74,
+    }
+
+    interpolated_values = np.minimum(interpolated_values, atomic_number[impurity_species])
     interpolated_values = np.maximum(interpolated_values, 0)
     return interpolated_values  # type:ignore[no-any-return]

--- a/cfspopcon/named_options.py
+++ b/cfspopcon/named_options.py
@@ -21,23 +21,23 @@ class RadiationMethod(Enum):
 
 
 class AtomicSpecies(Enum):
-    """Enum of possible atomic species.
+    """Enum of possible atomic species."""
 
-    The enum value represents the species atomic number (Z).
-    """
-
-    Hydrogen = 1
-    Helium = 2
-    Lithium = 3
-    Beryllium = 4
-    Carbon = 6
-    Nitrogen = 7
-    Oxygen = 8
-    Neon = 10
-    Argon = 18
-    Krypton = 36
-    Xenon = 54
-    Tungsten = 74
+    Hydrogen = auto()
+    Deuterium = auto()
+    Tritium = auto()
+    Helium = auto()
+    Lithium = auto()
+    Beryllium = auto()
+    Boron = auto()
+    Carbon = auto()
+    Nitrogen = auto()
+    Oxygen = auto()
+    Neon = auto()
+    Argon = auto()
+    Krypton = auto()
+    Xenon = auto()
+    Tungsten = auto()
 
     def __lt__(self, other: "AtomicSpecies") -> bool:
         """Implements '<' to allow sorting."""


### PR DESCRIPTION
D and T have different charge-exchange cross-sections, and so are now treated as different species by `radas`. This means that we can no longer set a unique value of atomic number for an `AtomicSpecies`, and instead need to handle their atomic number manually.