### PR TITLE
Remove percent, fix minor bug in n20 alias def

### DIFF
--- a/cfspopcon/unit_handling/setup_unit_handling.py
+++ b/cfspopcon/unit_handling/setup_unit_handling.py
@@ -26,8 +26,8 @@ Ret = TypeVar("Ret")
 
 # Define custom units for density as n_19 or n_20 (used in several formulas)
 # Format is "canonical_name = definition = unit_symbol = alias1 = alias2" where unit_symbol and aliases are optional
-ureg.define("n19 = 1e19 m^-3 = 1e19 m^-3")
-ureg.define("n20 = 1e20 m^-3 = 1e20 m^-3")
+ureg.define("n19 = 1e19 m^-3 = n19 = 1e19 m^-3")
+ureg.define("n20 = 1e20 m^-3 = n20 = 1e20 m^-3")
 
 # Needed for serialization/deserialization
 pint.set_application_registry(ureg)  # type:ignore[no-untyped-call]

--- a/cfspopcon/unit_handling/setup_unit_handling.py
+++ b/cfspopcon/unit_handling/setup_unit_handling.py
@@ -25,9 +25,9 @@ Params = ParamSpec("Params")
 Ret = TypeVar("Ret")
 
 # Define custom units for density as n_19 or n_20 (used in several formulas)
-ureg.define("_1e19_per_cubic_metre = 1e19 m^-3 = 1e19 m^-3 = n19")
-ureg.define("_1e20_per_cubic_metre = 1e20 m^-3 = 1e10 m^-3 = n20")
-ureg.define("percent = 0.01")
+# Format is "canonical_name = definition = unit_symbol = alias1 = alias2" where unit_symbol and aliases are optional
+ureg.define("n19 = 1e19 m^-3 = 1e19 m^-3")
+ureg.define("n20 = 1e20 m^-3 = 1e20 m^-3")
 
 # Needed for serialization/deserialization
 pint.set_application_registry(ureg)  # type:ignore[no-untyped-call]

--- a/cfspopcon/unit_handling/setup_unit_handling.py
+++ b/cfspopcon/unit_handling/setup_unit_handling.py
@@ -26,8 +26,8 @@ Ret = TypeVar("Ret")
 
 # Define custom units for density as n_19 or n_20 (used in several formulas)
 # Format is "canonical_name = definition = unit_symbol = alias1 = alias2" where unit_symbol and aliases are optional
-ureg.define("n19 = 1e19 m^-3 = n19 = 1e19 m^-3")
-ureg.define("n20 = 1e20 m^-3 = n20 = 1e20 m^-3")
+ureg.define("_1e19_per_cubic_metre = 1e19 m^-3 = 1e19 m^-3 = n19")
+ureg.define("_1e20_per_cubic_metre = 1e20 m^-3 = 1e20 m^-3 = n20")
 
 # Needed for serialization/deserialization
 pint.set_application_registry(ureg)  # type:ignore[no-untyped-call]

--- a/tests/test_infra/test_plotting.py
+++ b/tests/test_infra/test_plotting.py
@@ -38,4 +38,4 @@ def test_label_contour(z):
 def test_units_to_string():
     assert plotting.units_to_string(ureg.dimensionless) == ""
     assert plotting.units_to_string(ureg.m) == "[m]"
-    assert plotting.units_to_string(ureg.percent) == "[percent]"
+    assert plotting.units_to_string(ureg.percent) == "[%]"


### PR DESCRIPTION
Fixes a minor bug in the definition of `n20` units, where `1e10 m^-3` was aliased to `n20`. This **doesn't** mean that `n20` was being interpreted as `1e10 m^-3`, but it **does** mean that `Quantity(1, "1e10 m^-3")`.

Also, percent is now part of the `pint` default units (see https://github.com/hgrecco/pint/blob/master/pint/default_en.txt#L152) so we don't need to define it as a custom unit.