### PR TITLE
Update docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#jupyter-scipy-notebook
 # 
 # N.b. for mybinder.org, we need to pin to a specific tag
-FROM jupyter/scipy-notebook:x86_64-python-3.11.6
+FROM jupyter/minimal-notebook:python-3.11
 
 # 2. Install poetry, which is what we use to build cfspopcon
 RUN pip install poetry==1.8.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,22 +13,19 @@
 # https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html#jupyter-scipy-notebook
 # 
 # N.b. for mybinder.org, we need to pin to a specific tag
-FROM jupyter/scipy-notebook:848a82674792
+FROM jupyter/scipy-notebook:x86_64-python-3.11.6
 
-# 2. Install a fortran compiler into this image, so that we
-# can compile the radas headers
-RUN conda install -c conda-forge gfortran==13.2.0 -y
-# 3. Install poetry, which is what we use to build cfspopcon
+# 2. Install poetry, which is what we use to build cfspopcon
 RUN pip install poetry==1.8.2
 
-# 4. Copy in the files from the local directory
+# 3. Copy in the files from the local directory
 COPY --chown=$NB_USER:$NB_GID . ./
 
-# 5. Tell poetry to install in the global python environment,
+# 4. Tell poetry to install in the global python environment,
 # so we don't have to worry about custom kernels or venvs.
 RUN poetry config virtualenvs.create false
-# 6. Install cfspopcon in the global python environment.
+# 5. Install cfspopcon in the global python environment.
 RUN poetry install --without dev
 
-# 7. Run radas to get the atomic data files
+# 6. Run radas to get the atomic data files
 RUN poetry run radas


### PR DESCRIPTION
Needed for mybinder.org.

https://mybinder.org/v2/gh/cfs-energy/cfspopcon/update_docker_for_v7 now launches correctly.

* Switches to using `minimal-notebook` since the `scipy-notebook` seems to have some packages linked to numpy-1.x that aren't getting updated to numpy-2.x
* Removes the fortran compiler since we don't need it anymore with radas

<img width="2119" alt="Screenshot 2024-09-19 at 1 02 25 PM" src="https://github.com/user-attachments/assets/f06a20cf-2963-4f7b-80ba-1b3e34c823dd">
