### PR TITLE
Improve variable consistency checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,9 @@ cfspopcon: 0D Plasma Calculations & Plasma OPerating CONtours
 POPCONs (Plasma OPerating CONtours) is a tool developed to explore the performance and constraints of tokamak designs based on 0D scaling laws, model plasma kinetic profiles, and physics assumptions on the properties and behavior of the core plasma.
 
 All of our documentation is available at [cfspopcon.readthedocs.io](https://cfspopcon.readthedocs.io/en/latest/). There, you can find installation instructions, instructions for how to run `cfsPOPCON` via the command-line-interface and also explanations of the example Jupyter notebooks in [docs/doc_sources](docs/doc_sources).
+
+To re-generate the saved regression reference outputs in `tests/regression_results`, run the existing CLI helper from the repository root:
+
+```bash
+poetry run python tests/utils/regression_results.py
+```

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 import xarray as xr
+from utils.variable_consistency_checker import VariableConsistencyChecker
 
 from cfspopcon import named_options
 from cfspopcon.formulas.impurities.impurity_array_helpers import (
@@ -64,3 +65,9 @@ def test_impurity_array_helpers():
 
     assert np.isclose(ds["array2"].sel(dim_species=AtomicSpecies.Helium).isel(a=0, b=1).item(), 0.1)
     assert np.isclose(ds["array2"].sel(dim_species=AtomicSpecies.Tungsten).isel(a=1, b=1).item(), 0.4)
+
+
+def test_variable_consistency_checker_normalize_description():
+    assert VariableConsistencyChecker.normalize_description("single line") == ["single line"]
+    assert VariableConsistencyChecker.normalize_description("first line\nsecond line") == ["first line", "second line"]
+    assert VariableConsistencyChecker.normalize_description(["first line", "second line"]) == ["first line", "second line"]

--- a/tests/test_regression_against_cases.py
+++ b/tests/test_regression_against_cases.py
@@ -13,7 +13,18 @@ from xarray.testing import assert_allclose
 from cfspopcon.file_io import read_dataset_from_netcdf, write_dataset_to_netcdf
 from cfspopcon.input_file_handling import read_case
 
-ignored_variables = ["radas_version"]
+ignored_variables = [
+    "radas_version",
+]
+
+
+def assert_regression_datasets_allclose(dataset: xr.Dataset, reference_dataset: xr.Dataset) -> None:
+    """Compare regression datasets while accepting NaNs in matching locations."""
+    ordered_dims = [dim for dim in reference_dataset.dims]
+    assert_allclose(
+        dataset.transpose(*ordered_dims),
+        reference_dataset.transpose(*ordered_dims),
+    )
 
 
 @pytest.mark.regression
@@ -37,8 +48,7 @@ def test_regression_against_case(case: Path):
         .drop_vars(ignored_variables, errors="ignore")
     )
 
-    ordered_dims = [dim for dim in reference_dataset.dims]
-    assert_allclose(dataset.transpose(*ordered_dims), reference_dataset.transpose(*ordered_dims))
+    assert_regression_datasets_allclose(dataset, reference_dataset)
 
 
 @pytest.mark.regression
@@ -64,8 +74,7 @@ def test_regression_against_case_with_update(case: Path):
         .drop_vars(ignored_variables, errors="ignore")
     )
 
-    ordered_dims = [dim for dim in reference_dataset.dims]
-    assert_allclose(dataset.transpose(*ordered_dims), reference_dataset.transpose(*ordered_dims))
+    assert_regression_datasets_allclose(dataset, reference_dataset)
 
 
 @pytest.mark.regression
@@ -92,8 +101,4 @@ def test_regression_against_case_with_repeated_update():
     # The ordering of the dimensions changes between the runs, and for some reason the automatic
     # xarray broadcasting isn't handling this. Because of this, we manually ensure that the
     # dimension ordering matches.
-    ordered_dims = [dim for dim in first_run.dims]
-    assert_allclose(
-        first_run.transpose(*ordered_dims),
-        second_run.transpose(*ordered_dims),
-    )
+    assert_regression_datasets_allclose(first_run, second_run)

--- a/tests/utils/variable_consistency_checker.py
+++ b/tests/utils/variable_consistency_checker.py
@@ -39,8 +39,8 @@ class VariableConsistencyChecker:
 
         # Define patterns for identifying blank lines, keys and descriptions.
         pattern_for_key = re.compile(r"^\s{2}\S+\s*$")
-        pattern_for_description = re.compile(r"^\s{4}\S.+")
-        pattern_for_blank = re.compile(r"^\s*$")
+        pattern_for_description = re.compile(r"^\s{4}.*$")
+        pattern_for_blank = re.compile(r"^$")
 
         # Store the results in a dictionary
         glossary: dict[str, list[str]] = dict()
@@ -98,6 +98,24 @@ class VariableConsistencyChecker:
 
         return variables_dict, set(variables_dict.keys())
 
+    @staticmethod
+    def normalize_description(description: str | list[str]) -> list[str]:
+        """Normalize a variable description into a list of glossary lines.
+
+        ``variables.yaml`` historically contains a mix of plain strings and
+        explicit line lists. The glossary writer expects a list, so string
+        descriptions must be wrapped as single entries rather than iterated
+        character-by-character.
+        """
+        if isinstance(description, str):
+            return description.splitlines() or [description]
+
+        normalized_description: list[str] = []
+        for line in description:
+            normalized_description.extend(line.splitlines() or [line])
+
+        return normalized_description
+
     def run(self, apply_changes: bool = True) -> None:  # noqa: PLR0912, PLR0915
         """Check the files and, if apply_changes = True, modify the files in place."""
         success = True
@@ -153,7 +171,7 @@ class VariableConsistencyChecker:
                 default_units = self.variables_dict[key]["default_units"]
                 if default_units is not None:
                     default_units = str(Quantity(1.0, default_units).units)
-                description = self.variables_dict[key]["description"]
+                description = self.normalize_description(self.variables_dict[key]["description"])
                 if key not in self.glossary:
                     print(f"Adding description for '{key}'.{linebreak}New: '{description}'.{linebreak}")
                 elif not (description == self.glossary[key]):
@@ -204,8 +222,8 @@ class VariableConsistencyChecker:
                 for line in description:
                     glossary_text += [f"    {line}"]
 
-                with as_file(files("cfspopcon").parents[0] / "docs" / "doc_sources" / "physics_glossary.rst") as filepath:  # type:ignore[attr-defined]
-                    filepath.write_text("\n".join(glossary_text))
+            with as_file(files("cfspopcon").parents[0] / "docs" / "doc_sources" / "physics_glossary.rst") as filepath:  # type:ignore[attr-defined]
+                filepath.write_text("\n".join(glossary_text))
 
         exit(0) if success else exit(1)
 

--- a/tests/utils/variable_consistency_checker.py
+++ b/tests/utils/variable_consistency_checker.py
@@ -108,13 +108,13 @@ class VariableConsistencyChecker:
         character-by-character.
         """
         if isinstance(description, str):
-            return description.splitlines() or [description]
+            description = [description]
 
-        normalized_description: list[str] = []
+        result = []
         for line in description:
-            normalized_description.extend(line.splitlines() or [line])
-
-        return normalized_description
+            split = line.splitlines()
+            result.extend(split if split else [line])
+        return result
 
     def run(self, apply_changes: bool = True) -> None:  # noqa: PLR0912, PLR0915
         """Check the files and, if apply_changes = True, modify the files in place."""


### PR DESCRIPTION
- Fix the glossary autogenerator: `normalize_description` now wraps a plain-string description as a single line instead of iterating it character-by-character, and splits multi-line strings/lists into separate glossary lines.
- Loosen the glossary parser regexes for description/blank lines.
- Move the glossary file write out of the per-key loop so it's written once after all entries are built.
- Deduplicate the regression-comparison logic into a shared `assert_regression_datasets_allclose` helper.
- Add README instructions for regenerating the saved regression references (`poetry run python tests/utils/regression_results.py`).
- Add a `normalize_description` test.
