### PR TITLE
Move docs link-checking to a scheduled workflow

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,39 @@
+name: Docs Link Check
+
+# Link rot depends on third-party servers being up, not on anything we change,
+# so we check links on a timer instead of gating every PR and release on them.
+# A broken link fails this run, which surfaces in the Actions tab.
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # Mondays, 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  linkcheck:
+    name: Link check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pandoc
+
+      - name: Install Poetry
+        run: pipx install "poetry>=2,<3"
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: 'poetry'
+
+      - name: Install dependencies
+        run: poetry install
+
+      - name: Check documentation links
+        run: cd docs && poetry run make linkcheck

--- a/.github/workflows/workflow_actions.yml
+++ b/.github/workflows/workflow_actions.yml
@@ -180,9 +180,10 @@ jobs:
         run: poetry run pre-commit run --show-diff-on-failure --color=always --all-files
 
   # --- JOB 4: DOCUMENTATION ---
-  # Sphinx build (warnings as errors), doctests and linkcheck. Notebooks are
-  # not executed (nbsphinx_execute = "never"), so this is independent of the
-  # radas data and runs in parallel with everything else.
+  # Sphinx build (warnings as errors) and doctests. Notebooks are not executed
+  # (nbsphinx_execute = "never"), so this is independent of the radas data and
+  # runs in parallel with everything else. Link checking runs separately on a
+  # schedule (see linkcheck.yml) so flaky external links can't block a PR.
   docs:
     name: Documentation
     runs-on: ubuntu-latest
@@ -211,7 +212,6 @@ jobs:
           cd docs
           poetry run sphinx-build --keep-going -Wnb html . _build/
           poetry run make doctest
-          poetry run make linkcheck
 
   # --- JOB 5: PREPARE RELEASE ---
   build_release:


### PR DESCRIPTION
Link rot depends on third-party servers being up, not on anything we change, so running `linkcheck` on every PR and release let an unrelated dead link block merges and releases. This moves it to a weekly scheduled workflow (also manually triggerable). A broken link fails that run and surfaces in the Actions tab; nothing gates on it.

The `docs` job keeps the Sphinx build and doctests — those test our own changes and stay as gates. `docs` still exists, so no branch-protection changes are needed.

## Changes
- New `.github/workflows/linkcheck.yml`: `schedule` (Mondays 06:00 UTC) + `workflow_dispatch`, `contents: read`, mirrors the `docs` job environment and runs only `make linkcheck`.
- `workflow_actions.yml`: drop the `make linkcheck` step from the `docs` job.

## Verification
`actionlint` validates both workflows:

```
$ actionlint .github/workflows/linkcheck.yml .github/workflows/workflow_actions.yml
$ echo $?
0
```

The command itself is unchanged — `cd docs && poetry run make linkcheck`, the same step the `docs` job ran before — so it's known-good, just relocated.

After merge it can be run on demand via the `workflow_dispatch` trigger to confirm it works end-to-end:

```
gh workflow run "Docs Link Check"
gh run watch
```

Closes #143