### PR TITLE
Bump ReadTheDocs build to ubuntu-24.04 and Python 3.12

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-24.04"
   tools:
-    python: "3.10"
+    python: "3.12"
   jobs:
     post_create_environment:
       # Install poetry


### PR DESCRIPTION
`.readthedocs.yaml` pinned `os: ubuntu-20.04`, which ReadTheDocs no longer supports, so the docs build fails. This bumps the image to `ubuntu-24.04` and the build Python to `3.12` — the project requires `>=3.12`, so `poetry install` would fail on 3.10 even after the image fix, and 3.12 matches the Python the CI docs job already uses.

## Verification
`ubuntu-24.04` and Python `3.12` are both current ReadTheDocs-supported build options, and `3.12` satisfies `requires-python = ">=3.12"`. The build runs on ReadTheDocs (separate from GitHub Actions), so the conclusive check is the RTD build going green on this PR / after merge.

Closes #145