### PR TITLE
feat(plugins): add register_plugin() for external algorithm registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Forward energy-confinement algorithms** — `calc_energy_confinement_time_from_scaling` and `calc_energy_confinement_time_from_stored_energy_and_input_power`, giving `energy_confinement_time` from a known input power. (#141)
 - **`calc_H98y2`** — energy confinement time relative to the ITER98y2 scaling; adds the `H98y2` output. (#141)
 - **Fixed-auxiliary-power balance** — `calc_input_power_for_fixed_auxiliary_power` and the `calc_power_balance_from_input_P_aux` composite. (#141)
+- **`register_plugin()`**: import an external plugin module that registers its own algorithms, variables, and units, with clash detection, rollback, and a report of what was added. (#148)
 
 ### Changed
 

--- a/cfspopcon/__init__.py
+++ b/cfspopcon/__init__.py
@@ -11,6 +11,7 @@ from .deprecation_handler import handle_deprecated_arguments
 from .formulas.atomic_data import AtomicData
 from .input_file_handling import process_input_dictionary, read_case
 from .plotting import read_plot_style
+from .plugins import PluginClashError, PluginReport, register_plugin
 from .unit_handling import (
     convert_to_default_units,
     convert_units,
@@ -23,6 +24,8 @@ __all__ = [
     "Algorithm",
     "AtomicData",
     "CompositeAlgorithm",
+    "PluginClashError",
+    "PluginReport",
     "convert_to_default_units",
     "convert_units",
     "file_io",
@@ -33,6 +36,7 @@ __all__ = [
     "process_input_dictionary",
     "read_case",
     "read_plot_style",
+    "register_plugin",
     "set_default_units",
     "shaping_and_selection",
 ]

--- a/cfspopcon/plugins.py
+++ b/cfspopcon/plugins.py
@@ -1,0 +1,121 @@
+"""Explicit registration of external plugin modules."""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass, field
+
+from .algorithm_class import Algorithm
+from .unit_handling import ureg
+from .unit_handling.default_units import default_units_map, extend_default_units_map, reset_default_units
+
+
+@dataclass(frozen=True)
+class PluginReport:
+    """A summary of the algorithms, variables and units a plugin registered."""
+
+    plugin: str
+    algorithms: list[str] = field(default_factory=list)
+    variables: list[str] = field(default_factory=list)
+    units: list[str] = field(default_factory=list)
+
+    def __str__(self) -> str:
+        """Return a human-readable summary of the registered items."""
+        return (
+            f"Plugin '{self.plugin}' registered:\n"
+            f"  algorithms: {', '.join(self.algorithms) or '(none)'}\n"
+            f"  variables:  {', '.join(self.variables) or '(none)'}\n"
+            f"  units:      {', '.join(self.units) or '(none)'}"
+        )
+
+
+class PluginClashError(RuntimeError):
+    """Raised when a plugin redefines something cfspopcon already defines."""
+
+
+_successful_registrations: dict[str, PluginReport] = {}
+_failed_registrations: dict[str, PluginClashError] = {}
+
+
+def _restore_default_units(snapshot: dict[str, str]) -> None:
+    """Replace the default units map with the given snapshot."""
+    reset_default_units()
+    extend_default_units_map(snapshot)
+
+
+def _remove_algorithms(names: set[str]) -> None:
+    """Remove the given algorithm names from the Algorithm registry."""
+    for name in names:
+        Algorithm.instances.pop(name, None)
+
+
+def register_plugin(module_name: str) -> PluginReport:
+    """Import a plugin module and validate what it registers.
+
+    A plugin module is an ordinary Python module which registers algorithms,
+    variables and units at import time, using the same interfaces as cfspopcon's
+    built-in formula modules: the `Algorithm.register_algorithm` decorator,
+    `extend_default_units_map` and `ureg.define`. This function imports the
+    module, checks that it only adds to the registries (never redefines existing
+    entries), and reports what was added.
+
+    Repeated calls with the same module name return the original report, or
+    re-raise the original error, without importing again. A module that was
+    already imported by other means registers nothing new during this call, so
+    its report is empty.
+
+    Example::
+
+        report = cfspopcon.register_plugin("my_popcon_plugin")
+        print(report)
+
+    Args:
+        module_name: Importable name of the plugin module, e.g. "my_popcon_plugin".
+            This is the module's import name (underscores), which may differ from
+            the name of the distribution that provides it (often hyphenated).
+
+    Returns:
+        A summary of the algorithms, variables and units the plugin registered.
+
+    Raises:
+        PluginClashError: If the plugin changed the default units of an existing
+            variable. The plugin's registrations are rolled back before raising.
+    """
+    if module_name in _successful_registrations:
+        return _successful_registrations[module_name]
+    if module_name in _failed_registrations:
+        raise _failed_registrations[module_name]
+
+    units_before = default_units_map()
+    algorithms_before = set(Algorithm.instances)
+    pint_units_before = set(iter(ureg))
+
+    try:
+        importlib.import_module(module_name)
+    except Exception:
+        # A plugin that fails mid-import must leave no partial registrations behind.
+        _remove_algorithms(set(Algorithm.instances) - algorithms_before)
+        _restore_default_units(units_before)
+        raise
+
+    units_after = default_units_map()
+    clashes = {key: (units_before[key], units_after[key]) for key in units_before if units_after[key] != units_before[key]}
+    if clashes:
+        _remove_algorithms(set(Algorithm.instances) - algorithms_before)
+        _restore_default_units(units_before)
+        details = "\n".join(f"  {key}: '{old}' -> '{new}'" for key, (old, new) in clashes.items())
+        error = PluginClashError(f"Plugin '{module_name}' redefines the default units of existing variables (rolled back):\n{details}")
+        # The module stays cached in sys.modules with its side effects rolled back, so a
+        # repeated import would register nothing and look like a success. Cache the error
+        # to keep repeated calls consistent.
+        _failed_registrations[module_name] = error
+        raise error
+
+    report = PluginReport(
+        plugin=module_name,
+        algorithms=sorted(set(Algorithm.instances) - algorithms_before),
+        variables=sorted(set(units_after) - set(units_before)),
+        units=sorted(set(iter(ureg)) - pint_units_before),
+    )
+    _successful_registrations[module_name] = report
+    return report

--- a/cfspopcon/unit_handling/default_units.py
+++ b/cfspopcon/unit_handling/default_units.py
@@ -57,6 +57,15 @@ def extend_default_units_map(units_dictionary: dict[str, str]) -> None:
     _DEFAULT_UNITS |= units_dictionary
 
 
+def default_units_map() -> dict[str, str]:
+    """Return a copy of the registered default units map.
+
+    Returns:
+        Mapping from variable name to the name of its default unit.
+    """
+    return dict(_DEFAULT_UNITS)
+
+
 def reset_default_units() -> None:
     """Reset the default units to an empty dictionary."""
     global _DEFAULT_UNITS  # noqa: PLW0603

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,137 @@
+"""Tests for cfspopcon.plugins.register_plugin."""
+
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from cfspopcon import Algorithm, PluginClashError, register_plugin
+from cfspopcon.plugins import _failed_registrations, _successful_registrations
+from cfspopcon.unit_handling import ureg
+from cfspopcon.unit_handling.default_units import default_unit, default_units_map, extend_default_units_map, reset_default_units
+
+OK_PLUGIN = dedent(
+    """
+    from cfspopcon.algorithm_class import Algorithm
+    from cfspopcon.unit_handling import Unitfull
+    from cfspopcon.unit_handling.default_units import extend_default_units_map
+
+    extend_default_units_map({"test_plugin_metric": "dimensionless"})
+
+    @Algorithm.register_algorithm(return_keys=["test_plugin_metric"])
+    def calc_test_plugin_metric(average_electron_density: Unitfull, greenwald_density_limit: Unitfull) -> Unitfull:
+        return average_electron_density / greenwald_density_limit
+    """
+)
+
+CLASH_PLUGIN = dedent(
+    """
+    from cfspopcon.algorithm_class import Algorithm
+    from cfspopcon.unit_handling import Unitfull
+    from cfspopcon.unit_handling.default_units import extend_default_units_map
+
+    extend_default_units_map({"average_electron_density": "electron_volt"})
+
+    @Algorithm.register_algorithm(return_keys=["average_electron_density"])
+    def calc_clash_plugin_metric(major_radius: Unitfull) -> Unitfull:
+        return major_radius
+    """
+)
+
+BROKEN_PLUGIN = dedent(
+    """
+    from cfspopcon.unit_handling.default_units import extend_default_units_map
+
+    extend_default_units_map({"test_broken_plugin_metric": "dimensionless"})
+    raise ImportError("broken plugin")
+    """
+)
+
+
+@pytest.fixture(autouse=True)
+def restore_registries(monkeypatch, tmp_path):
+    """Isolate the global registries and make tmp_path importable."""
+    monkeypatch.syspath_prepend(str(tmp_path))
+    algorithms_before = set(Algorithm.instances)
+    units_before = default_units_map()
+    modules_before = set(sys.modules)
+
+    yield
+
+    for name in set(Algorithm.instances) - algorithms_before:
+        del Algorithm.instances[name]
+    reset_default_units()
+    extend_default_units_map(units_before)
+    for name in set(sys.modules) - modules_before:
+        del sys.modules[name]
+    _successful_registrations.clear()
+    _failed_registrations.clear()
+
+
+def write_plugin(tmp_path: Path, name: str, source: str) -> str:
+    """Write a plugin module into tmp_path and return its import name."""
+    (tmp_path / f"{name}.py").write_text(source)
+    return name
+
+
+def test_register_plugin_reports_additions(tmp_path):
+    """A well-behaved plugin registers and its report lists the additions."""
+    name = write_plugin(tmp_path, "popcon_test_plugin_ok", OK_PLUGIN)
+
+    report = register_plugin(name)
+
+    assert report.algorithms == ["calc_test_plugin_metric"]
+    assert report.variables == ["test_plugin_metric"]
+    assert report.units == []
+    assert default_unit("test_plugin_metric") == "dimensionless"
+    assert "calc_test_plugin_metric" in str(Algorithm.get_algorithm("calc_test_plugin_metric").__doc__)
+
+
+def test_registered_algorithm_runs_in_composite_chain(tmp_path):
+    """A plugin algorithm composes and runs with built-in algorithms."""
+    name = write_plugin(tmp_path, "popcon_test_plugin_chain", OK_PLUGIN)
+    register_plugin(name)
+
+    workflow = Algorithm.get_algorithm("calc_greenwald_density_limit") + Algorithm.get_algorithm("calc_test_plugin_metric")
+    dataset = workflow.run(
+        plasma_current=ureg.Quantity(8.7, "MA"),
+        minor_radius=ureg.Quantity(0.57, "m"),
+        average_electron_density=ureg.Quantity(25.0, "_1e19_per_cubic_metre"),
+    )
+
+    assert dataset["test_plugin_metric"].item() == pytest.approx(25.0 / 85.235, rel=1e-3)
+
+
+def test_register_plugin_is_idempotent(tmp_path):
+    """Registering the same plugin twice returns the original report."""
+    name = write_plugin(tmp_path, "popcon_test_plugin_twice", OK_PLUGIN)
+
+    report = register_plugin(name)
+
+    assert register_plugin(name) is report
+
+
+def test_clash_is_rejected_and_rolled_back(tmp_path):
+    """A plugin redefining an existing variable is rejected and rolled back."""
+    name = write_plugin(tmp_path, "popcon_test_plugin_clash", CLASH_PLUGIN)
+
+    with pytest.raises(PluginClashError, match="average_electron_density"):
+        register_plugin(name)
+
+    assert default_unit("average_electron_density") == "_1e19_per_cubic_metre"
+    assert "calc_clash_plugin_metric" not in Algorithm.instances
+
+    # Repeated calls raise the same error instead of reporting an empty success.
+    with pytest.raises(PluginClashError, match="average_electron_density"):
+        register_plugin(name)
+
+
+def test_failed_import_is_rolled_back(tmp_path):
+    """A plugin that raises during import leaves no partial registrations."""
+    name = write_plugin(tmp_path, "popcon_test_plugin_broken", BROKEN_PLUGIN)
+
+    with pytest.raises(ImportError, match="broken plugin"):
+        register_plugin(name)
+
+    assert "test_broken_plugin_metric" not in default_units_map()


### PR DESCRIPTION
Implements #148: an explicit entry point for external packages (or local try-out modules) to register their own algorithms, variables, and units.

```python
import cfspopcon

report = cfspopcon.register_plugin("popcon_myext")
print(report)
# Plugin 'popcon_myext' registered:
#   algorithms: calc_density_limit_margin
#   variables:  density_limit_margin
#   units:      n18
```

The plugin module is written exactly like a core formula module (same decorator, same `extend_default_units_map`, same `ureg.define`); `register_plugin` wraps the import with a before/after snapshot of the registries so it can:

- reject a plugin that changes an existing variable's default units, rolling its registrations back (`PluginClashError`); `extend_default_units_map` alone overwrites silently
- roll back partial registrations when a plugin fails mid-import
- return a `PluginReport` manifest of added algorithms, variables, and units
- stay idempotent: repeated calls return the original report or re-raise the original error

Also adds a public `default_units_map()` accessor to `unit_handling.default_units`, so the snapshot needs no private state.

## Verification

```
poetry run pytest tests/test_plugins.py
```

5 tests: report contents, mixed built-in + plugin composite chain, idempotency, clash rejection + rollback, failed-import rollback. `mypy` and `ruff` clean.

## Limitations / follow-ups

- pint unit definitions cannot be undone, so a rejected plugin's `ureg.define` calls persist for the session.
- Re-registering an algorithm name still raises unconditionally in `Algorithm.__init__` (the check fires before `skip_registration` is read); an explicit overwrite path is a separate fix.
- Entry-point auto-discovery and a `plugins:` key in `input.yaml` are out of scope here and can build on this.