### PR TITLE
Fix the docstring of a named CompositeAlgorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`calc_analytic_profiles`, `calc_prf_profiles` algorithms** now take `rho` as an input and no longer return it; the `npoints` argument is removed. (#139)
 - **`wraps_ufunc`** infers `output_core_dims` from the number of return units, so multi-return functions no longer need to pass it explicitly. (#141)
 
+### Fixed
+
+- **A named `CompositeAlgorithm`'s docstring** listed only its name. Operator precedence between the conditional expression and the implicitly concatenated strings meant the components, inputs and outputs were built only for an unnamed composite; since every registered composite is named, they were missing everywhere they were used.
+
 ### Removed
 
 - **`calc_peaked_profiles`, `calc_1D_plasma_profiles` algorithms** — replaced by `calc_peaking_and_analytic_profiles` / `calc_peaking_and_prf_profiles`. (#139)

--- a/cfspopcon/algorithm_class.py
+++ b/cfspopcon/algorithm_class.py
@@ -350,13 +350,8 @@ class CompositeAlgorithm:
         """Makes a doc-string detailing the function inputs and outputs."""
         components = f"[{', '.join(alg._name for alg in self.algorithms)}]"
 
-        return_string = (
-            f"CompositeAlgorithm: {self._name}\n"
-            if self._name is not None
-            else "CompositeAlgorithm\n"
-            f"Composed of {components}\n"
-            f"Inputs:\n{', '.join(self.input_keys)}\n"
-            f"Outputs:\n{', '.join(self.return_keys)}"
+        return_string = (f"CompositeAlgorithm: {self._name}\n" if self._name is not None else "CompositeAlgorithm\n") + (
+            f"Composed of {components}\nInputs:\n{', '.join(self.input_keys)}\nOutputs:\n{', '.join(self.return_keys)}"
         )
         return return_string
 

--- a/tests/test_algorithms_class.py
+++ b/tests/test_algorithms_class.py
@@ -300,3 +300,13 @@ def test_call_single_output_is_unwrapped():
 
     alg = Algorithm(function=add_one, return_keys=["y"], skip_registration=True)
     assert alg(x=4) == 5
+
+
+def test_named_composite_docstring_lists_its_components(how_many_birds: Algorithm, how_many_animals: Algorithm):
+    composite = CompositeAlgorithm([how_many_birds, how_many_animals], name="count_the_farm")
+
+    assert composite.__doc__ is not None
+    assert composite.__doc__.startswith("CompositeAlgorithm: count_the_farm\n")
+    assert "Composed of [count_birds, count_animals]" in composite.__doc__
+    assert "Inputs:\n" in composite.__doc__
+    assert "Outputs:\n" in composite.__doc__


### PR DESCRIPTION
Split out of #147, which will be closed in favour of this and the other pieces it has been divided into. This one is independent of the rest: it fixes a bug that predates that branch, and it can merge at any time, in any order.

## What this changes

`CompositeAlgorithm._make_docstring` assembled a docstring listing the composite's components, inputs and outputs. For a *named* composite it produced only the first line:

```
CompositeAlgorithm: calc_peaking_and_analytic_profiles
```

The cause is operator precedence between the conditional expression and the implicitly concatenated string literals that followed it:

```python
return_string = (
    f"CompositeAlgorithm: {self._name}\n"
    if self._name is not None
    else "CompositeAlgorithm\n"          # <-- the three lines below bind to this branch,
    f"Composed of {components}\n"        #     not to the expression as a whole
    f"Inputs:\n{', '.join(self.input_keys)}\n"
    f"Outputs:\n{', '.join(self.return_keys)}"
)
```

The implicit concatenation binds tighter than the conditional, so the components/inputs/outputs section was part of the `else` branch — it was assembled *only* for an unnamed composite. Parenthesising the conditional fixes it.

## Why it is needed

Every composite that is registered is named, so this applied to all of them: their `__doc__` carried nothing but a name, everywhere it was used (`help()`, the API docs, anything reading `__doc__`). Unnamed composites — the ones built ad hoc by `a + b` — were unaffected, which is why it went unnoticed.

## Verification

- New test `test_named_composite_docstring_lists_its_components` asserts the four parts of the assembled docstring.
- Mutation-checked: with the fix reverted the new test fails (`1 failed, 13 passed`) and passes with it, so it is pinning the behaviour rather than passing incidentally.
- Full suite bare (`pytest -q --no-cov -p no:randomly`, so the four `--nbmake` notebook tests are included): **154 passed**.
- `ruff check cfspopcon/` and `ruff format --check cfspopcon/ tests/` clean; `mypy cfspopcon/` reports **58 errors in 5 files**, identical to `main`.
- `tests/utils/variable_consistency_checker.py` exits 0.

## Risks / what to look at

- Low risk: the change is confined to a docstring-building expression and no code branches on `__doc__`.
- The one thing worth a glance is whether the reformatted expression is what you would have written — the fix keeps a two-part concatenation rather than restructuring the function, to stay a minimal diff.
- If anything downstream string-matched the old (truncated) docstring, it will now see the full text. Nothing in this repository does.
