### PR TITLE
Export extend_default_units_map from cfspopcon.unit_handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Forward energy-confinement algorithms** — `calc_energy_confinement_time_from_scaling` and `calc_energy_confinement_time_from_stored_energy_and_input_power`, giving `energy_confinement_time` from a known input power. (#141)
 - **`calc_H98y2`** — energy confinement time relative to the ITER98y2 scaling; adds the `H98y2` output. (#141)
 - **Fixed-auxiliary-power balance** — `calc_input_power_for_fixed_auxiliary_power` and the `calc_power_balance_from_input_P_aux` composite. (#141)
+- **`extend_default_units_map` is exported from `cfspopcon.unit_handling`** — the supported way for a downstream package to declare default units for variables of its own, since `read_default_units_from_file()` reads only cfspopcon's `variables.yaml` and takes no path argument. It was previously reachable only from `cfspopcon.unit_handling.default_units`.
 
 ### Changed
 

--- a/cfspopcon/unit_handling/__init__.py
+++ b/cfspopcon/unit_handling/__init__.py
@@ -4,7 +4,13 @@ import xarray as xr
 from pint import DimensionalityError, UndefinedUnitError, UnitStrippedWarning
 
 from .decorator import wraps_ufunc
-from .default_units import convert_to_default_units, default_unit, magnitude_in_default_units, set_default_units
+from .default_units import (
+    convert_to_default_units,
+    default_unit,
+    extend_default_units_map,
+    magnitude_in_default_units,
+    set_default_units,
+)
 from .setup_unit_handling import (
     Quantity,
     Unit,
@@ -29,6 +35,7 @@ __all__ = [
     "convert_units",
     "default_unit",
     "dimensionless_magnitude",
+    "extend_default_units_map",
     "get_units",
     "magnitude",
     "magnitude_in_default_units",


### PR DESCRIPTION
Split out of #147, which will be closed in favour of this and the other pieces it has been divided into.

**Merge this before the algorithm-discovery PR** — that branch is stacked on this one, because its downstream-extension tests and its new notebook section on declaring units use the public name.

## What this changes

`extend_default_units_map` is exported from `cfspopcon.unit_handling` (added to the `from .default_units import ...` list and to `__all__`). Two lines, plus a CHANGELOG entry. No behaviour change.

## Why it is needed

It is the only supported way for a package built on cfspopcon to declare default units for variables of its own:

- `_DEFAULT_UNITS` is a module global in `cfspopcon/unit_handling/default_units.py`, filled by `read_default_units_from_file()` at import of that module.
- `read_default_units_from_file()` reads cfspopcon's own `cfspopcon/variables.yaml` and **takes no path argument**, so a downstream package cannot point it at its own YAML.
- `default_unit(var)` raises `KeyError` for a name that is not in the map, so a downstream algorithm whose return key is unknown fails at unit-conversion time unless it sets `skip_unit_conversion`.

So the route is: load your own YAML and pass the mapping to `extend_default_units_map({"my_var": "keV"})`. This is already what extended-lengyel does (`extended_units.yaml` + `extend_default_units_map`). Until now that meant reaching past the package's public surface into `cfspopcon.unit_handling.default_units`, even though `cfspopcon.unit_handling` exported the four neighbouring functions (`convert_to_default_units`, `default_unit`, `magnitude_in_default_units`, `set_default_units`).

## Verification

- `from cfspopcon.unit_handling import extend_default_units_map` resolves.
- Full suite bare (notebooks included): **153 passed**.
- `ruff check` / `ruff format --check` clean; `mypy cfspopcon/` reports **58 errors in 5 files**, identical to `main`.

## Risks / what to look at

- The decision itself rather than the diff: this promotes a function that mutates process-global unit state to public API, and the commitment is that it stays. If you would rather the supported route were a `read_default_units_from_file(path)` overload, or a registry-style API, say so now — the two-line export is easy to withdraw, a published name is not.
- `extend_default_units_map` validates its argument (`check_units_are_valid`) and merges with `|=`, so a caller can silently *replace* an existing cfspopcon default for a name that collides. That behaviour is unchanged here, but it becomes easier to reach. It may deserve a follow-up.
- Its docstring is one line; if you want the public version to document the global-state effect and the collision behaviour, that is worth adding before merge.
