### PR TITLE
Replace set_by/used_by bookkeeping with live registry queries, and hint at fixes in validate_inputs

### DIFF
--- a/cfspopcon/__init__.py
+++ b/cfspopcon/__init__.py
@@ -9,9 +9,12 @@ from . import file_io, formulas, named_options, shaping_and_selection
 from .algorithm_class import (
     Algorithm,
     CompositeAlgorithm,
+    algorithms_setting,
+    algorithms_using,
     discover_algorithms_in_package,
     discover_algorithms_in_packages,
     discover_builtin_algorithms,
+    registered_algorithms,
     registry,
 )
 from .deprecation_handler import handle_deprecated_arguments
@@ -31,6 +34,8 @@ __all__ = [
     "CompositeAlgorithm",
     "PluginClashError",
     "PluginReport",
+    "algorithms_setting",
+    "algorithms_using",
     "convert_to_default_units",
     "convert_units",
     "discover_algorithms_in_package",
@@ -46,6 +51,7 @@ __all__ = [
     "read_plot_style",
     "register_plugin",
     "register_plugins",
+    "registered_algorithms",
     "registry",
     "set_default_units",
     "shaping_and_selection",

--- a/cfspopcon/algorithm_class.py
+++ b/cfspopcon/algorithm_class.py
@@ -142,6 +142,11 @@ class Algorithm:
         )
         return return_string
 
+    @property
+    def name(self) -> str:
+        """The name this algorithm is registered under (the function's name unless overridden)."""
+        return self._name
+
     def __repr__(self) -> str:
         """Return a simple string description of the Algorithm."""
         return f"Algorithm: {self._name}"
@@ -431,7 +436,7 @@ class CompositeAlgorithm:
 
     def _make_docstring(self) -> str:
         """Makes a doc-string detailing the function inputs and outputs."""
-        components = f"[{', '.join(alg._name for alg in self.algorithms)}]"
+        components = f"[{', '.join(alg.name for alg in self.algorithms)}]"
 
         return_string = (
             f"CompositeAlgorithm: {self._name}\n"
@@ -442,6 +447,11 @@ class CompositeAlgorithm:
             f"Outputs:\n{', '.join(self.return_keys)}"
         )
         return return_string
+
+    @property
+    def name(self) -> str | None:
+        """The name this composite is registered under, or None for an unnamed composite."""
+        return self._name
 
     def __repr__(self) -> str:
         """Return a simple string description of the CompositeAlgorithm."""
@@ -463,7 +473,7 @@ class CompositeAlgorithm:
                 needed_by[parameter] = []
                 for alg in self.algorithms:
                     if parameter in alg.input_keys:
-                        needed_by[parameter].append(alg._name)
+                        needed_by[parameter].append(alg.name)
 
             error_string = ", ".join(f"{key} needed by [{', '.join(val)}]" for key, val in needed_by.items())
             raise TypeError(f"CompositeAlgorithm.run() missing arguments: {error_string}")
@@ -516,9 +526,9 @@ class CompositeAlgorithm:
         for algorithm in self.algorithms:
             for key in algorithm.return_keys:
                 if key not in key_setter.keys():
-                    key_setter[key] = [algorithm._name]
+                    key_setter[key] = [algorithm.name]
                 else:
-                    key_setter[key].append(algorithm._name)
+                    key_setter[key].append(algorithm.name)
 
         overridden_variables = []
         for variable, algs in key_setter.items():

--- a/cfspopcon/algorithm_class.py
+++ b/cfspopcon/algorithm_class.py
@@ -705,6 +705,24 @@ def registered_algorithms() -> dict[str, Algorithm | CompositeAlgorithm]:
     return dict(Algorithm.instances)
 
 
+def algorithms_setting(variable: str) -> list[str]:
+    """Return the names of the registered algorithms whose outputs include ``variable``, sorted.
+
+    Scans the live registry, so plugin algorithms appear once registered and nothing appears until
+    discovery has run. Composites are excluded: every composite containing a setter would repeat
+    it, and each one contains a plain Algorithm which sets the variable anyway.
+    """
+    return sorted(name for name, alg in Algorithm.instances.items() if isinstance(alg, Algorithm) and variable in alg.return_keys)
+
+
+def algorithms_using(variable: str) -> list[str]:
+    """Return the names of the registered algorithms whose inputs include ``variable``, sorted.
+
+    See :func:`algorithms_setting` for the scan's scope.
+    """
+    return sorted(name for name, alg in Algorithm.instances.items() if isinstance(alg, Algorithm) and variable in alg.input_keys)
+
+
 def pending_composites() -> list[tuple[str, list[str]]]:
     """Return a copy of the composites declared but not yet built, as (name, component names)."""
     return [(name, list(keys)) for name, keys in _pending_composites]

--- a/cfspopcon/algorithm_class.py
+++ b/cfspopcon/algorithm_class.py
@@ -592,25 +592,38 @@ def _validate_inputs(
             # which can be provided (but which might have default values).
             unused_config_keys.remove(key)
 
-    if len(missing_input_keys) == 0 and len(unused_config_keys) == 0:
+    missing = sorted(missing_input_keys)
+    unused = sorted(unused_config_keys)
+
+    if not missing and not unused:
         return True
-
-    elif len(missing_input_keys) > 0 and len(unused_config_keys) > 0:
-        message = f"Missing input parameters [{', '.join(missing_input_keys)}]. Also had unused input parameters [{', '.join(unused_config_keys)}]."
-        if raise_error_on_missing_inputs:
-            raise RuntimeError(message)
-
-    elif len(missing_input_keys) > 0:
-        message = f"Missing input parameters [{', '.join(missing_input_keys)}]."
-        if raise_error_on_missing_inputs:
-            raise RuntimeError(message)
-
+    elif missing and unused:
+        message = f"Missing input parameters [{', '.join(missing)}]. Also had unused input parameters [{', '.join(unused)}]."
+    elif missing:
+        message = f"Missing input parameters [{', '.join(missing)}]."
     else:
-        message = f"Unused input parameters [{', '.join(unused_config_keys)}]."
+        message = f"Unused input parameters [{', '.join(unused)}]."
+    message = "\n".join([message, *_input_hints(algorithm, missing, unused)])
 
+    if missing and raise_error_on_missing_inputs:
+        raise RuntimeError(message)
     if not quiet:
         warn(message, stacklevel=3)
     return False
+
+
+def _input_hints(algorithm: Algorithm | CompositeAlgorithm, missing: list[str], unused: list[str]) -> list[str]:
+    """Suggest a fix per missing or unused input, where the registry or a near-miss offers one."""
+    hints = []
+    for key in missing:
+        setters = algorithms_setting(key)
+        if setters:
+            hints.append(f"'{key}' is set by [{', '.join(setters)}]: add one to your algorithms list, or provide '{key}' as an input.")
+    for key in unused:
+        close_matches = get_close_matches(key, algorithm.input_keys, n=1)
+        if close_matches:
+            hints.append(f"Unused parameter '{key}': did you mean '{close_matches[0]}'?")
+    return hints
 
 
 def build_pending_composites() -> None:

--- a/cfspopcon/cli.py
+++ b/cfspopcon/cli.py
@@ -46,11 +46,14 @@ def run_popcon_cli(case: str, show: bool, debug: bool, kwargs: tuple[tuple[str, 
 
 @click.command()
 @click.option("-o", "--output", default="./popcon_algorithms.yaml", type=click.Path(exists=False))
-def write_algorithms_yaml(output: str) -> None:
+@click.option("--plugin", "-p", "plugins", multiple=True, help="Also register this plugin package (repeatable).")
+def write_algorithms_yaml(output: str, plugins: tuple[str, ...]) -> None:
     """Write all available algorithms to a yaml helper file."""
-    from cfspopcon import Algorithm
+    from cfspopcon import Algorithm, register_plugins
 
     discover_builtin_algorithms()
+    if plugins:
+        register_plugins(*plugins)
     Algorithm.write_yaml(Path(output))
 
 

--- a/cfspopcon/deprecation_handler.py
+++ b/cfspopcon/deprecation_handler.py
@@ -39,7 +39,7 @@ def handle_deprecated_arguments(
         else:
             raise NotImplementedError(f"Cannot handle a profile type of {profile_type}")
 
-        updated_alg_list = [new_alg if alg._name == "calc_peaked_profiles" else alg for alg in algorithm.algorithms]
+        updated_alg_list = [new_alg if alg.name == "calc_peaked_profiles" else alg for alg in algorithm.algorithms]
         algorithm = CompositeAlgorithm(
             algorithms=updated_alg_list,
         )

--- a/cfspopcon/variables.yaml
+++ b/cfspopcon/variables.yaml
@@ -2,552 +2,209 @@ alpha_t:
   default_units: dimensionless
   description:
   - Turbulence characterization parameter used by the separatrix operational space.
-  set_by:
-  - calc_alpha_t
-  used_by:
-  - calc_SepOS_LH_transition
-  - calc_SepOS_ideal_MHD_limit
-  - calc_SepOS_L_mode_density_limit
-  - calc_power_crossing_separatrix_in_ion_channel
-  - calc_power_crossing_separatrix_in_electron_channel
 areal_elongation:
   default_units: dimensionless
   description:
   - Elongation of the confined region computed using the poloidal area inside the
     last-closed-flux-surface :math:`\kappa_A = S_{pol} / (\pi a^2)`.
-  set_by:
-  - calc_areal_elongation_from_elongation_at_psi95
-  used_by:
-  - calc_energy_confinement_time_from_scaling
-  - calc_H98y2
-  - solve_energy_confinement_scaling_for_input_power
-  - switch_to_linearised_ohmic_confinement_below_threshold
-  - switch_to_L_mode_confinement_below_threshold
-  - calc_plasma_volume
-  - calc_plasma_surface_area
-  - calc_plasma_poloidal_circumference
-  - calc_elongation_at_psi95_from_areal_elongation
-  - calc_separatrix_elongation_from_areal_elongation
-  - calc_external_inductance
-  - calc_vertical_field_mutual_inductance
-  - calc_invmu_0_dLedR
-  - calc_vertical_magnetic_field
-  - calc_current_relaxation_time
-  - calc_loop_voltage
-  - calc_f_shaping_for_qstar
-  - calc_power_balance_from_input_P_aux
 atomic_data:
   default_units: null
   description:
   - Dictionary mapping :class:`~cfspopcon.named_options.AtomicSpecies` to datasets
     giving coronal and non-coronal :math:`L_z` radiated power factors and :math:`\langle
     Z \rangle` mean charge state curves from `radas <https://github.com/cfs-energy/radas>`_.
-  set_by:
-  - read_atomic_data
-  used_by:
-  - calc_impurity_radiated_power_radas
-  - calc_impurity_radiated_power
-  - calc_intrinsic_radiated_power_from_core
-  - calc_core_seeded_impurity_concentration
-  - calc_edge_impurity_concentration
-  - calc_impurity_charge_state
-  - calc_zeff_and_dilution_due_to_impurities
 average_electron_density:
   default_units: _1e19_per_cubic_metre
   description:
   - Volume-averaged electron density in the confined region :math:`\bar n_e`.
-  set_by:
-  - calc_average_electron_density_from_greenwald_fraction
-  used_by:
-  - calc_energy_confinement_time_from_scaling
-  - calc_H98y2
-  - calc_plasma_stored_energy
-  - solve_energy_confinement_scaling_for_input_power
-  - switch_to_linearised_ohmic_confinement_below_threshold
-  - switch_to_L_mode_confinement_below_threshold
-  - calc_impurity_charge_state
-  - calc_zeff_and_dilution_due_to_impurities
-  - calc_normalised_collisionality
-  - calc_greenwald_fraction
-  - calc_PBpRnSq
-  - calc_beta_toroidal
-  - calc_beta_poloidal
-  - calc_average_total_pressure
-  - calc_ion_density_peaking
-  - calc_electron_density_peaking
-  - calc_effective_collisionality
-  - calc_jch_profiles
-  - calc_analytic_profiles
-  - calc_prf_profiles
-  - two_point_model_fixed_fpow
-  - two_point_model_fixed_qpart
-  - calc_separatrix_electron_density
-  - calc_LH_transition_threshold_power
-  - calc_LI_transition_threshold_power
-  - calc_power_balance_from_input_P_aux
-  - calc_peaking_and_analytic_profiles
-  - calc_peaking_and_prf_profiles
 average_electron_temp:
   default_units: kiloelectron_volt
   description:
   - Volume-averaged electron temperature in the confined region :math:`\bar T_e`.
-  set_by: []
-  used_by:
-  - calc_plasma_stored_energy
-  - calc_impurity_charge_state
-  - calc_zeff_and_dilution_due_to_impurities
-  - calc_normalised_collisionality
-  - calc_Spitzer_loop_resistivity
-  - calc_current_relaxation_time
-  - calc_beta_toroidal
-  - calc_beta_poloidal
-  - calc_average_ion_temp_from_temperature_ratio
-  - calc_average_total_pressure
-  - calc_effective_collisionality
-  - calc_jch_profiles
-  - calc_jch_pedestal_peaking
-  - calc_analytic_profiles
-  - calc_prf_profiles
-  - calc_peak_electron_temp
-  - calc_temperature_peaking
-  - calc_peaking_and_analytic_profiles
-  - calc_peaking_and_prf_profiles
 average_ion_density:
   default_units: _1e19_per_cubic_metre
   description:
   - Volume-averaged ion density in the confined region :math:`\bar n_i`.
-  set_by:
-  - calc_zeff_and_dilution_due_to_impurities
-  used_by:
-  - calc_plasma_stored_energy
 average_ion_mass:
   default_units: unified_atomic_mass_unit
   description:
   - Average mass of fuel ions, with the average weighted by the relative concentration
     of each species.
-  set_by:
-  - calc_average_ion_mass
-  used_by:
-  - calc_energy_confinement_time_from_scaling
-  - calc_H98y2
-  - solve_energy_confinement_scaling_for_input_power
-  - switch_to_linearised_ohmic_confinement_below_threshold
-  - switch_to_L_mode_confinement_below_threshold
-  - calc_alpha_t
-  - calc_edge_collisionality
-  - calc_rho_star
-  - two_point_model_fixed_fpow
-  - two_point_model_fixed_qpart
-  - two_point_model_fixed_tet
-  - calc_neutral_pressure_kallenbach
-  - calc_neutral_flux_density_factor
-  - calc_poloidal_sound_larmor_radius
-  - calc_SepOS_LH_transition
-  - calc_SepOS_L_mode_density_limit
-  - calc_LH_transition_threshold_power
-  - calc_power_balance_from_input_P_aux
 average_ion_temp:
   default_units: kiloelectron_volt
   description:
   - Volume-averaged ion temperature in the confined region :math:`\bar T_i`.
-  set_by:
-  - calc_average_ion_temp_from_temperature_ratio
-  used_by:
-  - calc_plasma_stored_energy
-  - calc_normalised_collisionality
-  - calc_rho_star
-  - calc_beta_toroidal
-  - calc_beta_poloidal
-  - calc_average_total_pressure
-  - calc_jch_profiles
-  - calc_jch_pedestal_peaking
-  - calc_analytic_profiles
-  - calc_prf_profiles
-  - calc_peak_ion_temp
-  - calc_temperature_peaking
-  - calc_peaking_and_analytic_profiles
-  - calc_peaking_and_prf_profiles
 average_total_pressure:
   default_units: pascal
   description:
   - Sum of electron and ion pressures.
-  set_by:
-  - calc_average_total_pressure
-  used_by:
-  - calc_lambda_q
-  - calc_lambda_q_with_brunner
 B_pol_out_mid:
   default_units: tesla
   description:
   - Poloidal magnetic field at outboard midplane separatrix
-  set_by:
-  - calc_B_pol_omp
-  used_by:
-  - calc_fieldline_pitch_at_omp
-  - calc_lambda_q
-  - calc_lambda_q_with_eich_regression_14
-  - calc_lambda_q_with_eich_regression_15
-  - calc_power_crossing_separatrix_in_electron_channel
 B_t_out_mid:
   default_units: tesla
   description:
   - Toroidal magnetic field at outboard midplane separatrix
-  set_by:
-  - calc_B_tor_omp
-  used_by:
-  - calc_fieldline_pitch_at_omp
-  - calc_power_crossing_separatrix_in_electron_channel
 beta_poloidal:
   default_units: dimensionless
   description:
   - Ratio of plasma pressure to magnetic pressure provided by the poloidal magnetic
     field.
-  set_by:
-  - calc_beta_poloidal
-  used_by:
-  - calc_bootstrap_fraction
-  - calc_external_inductance
-  - calc_invmu_0_dLedR
-  - calc_vertical_magnetic_field
-  - calc_beta_total
 beta_toroidal:
   default_units: dimensionless
   description:
   - Ratio of plasma pressure to magnetic pressure provided by the toroidal magnetic
     field.
-  set_by:
-  - calc_beta_toroidal
-  used_by:
-  - calc_beta_total
-  - calc_ion_density_peaking
-  - calc_electron_density_peaking
-  - calc_peaking_and_analytic_profiles
-  - calc_peaking_and_prf_profiles
 beta_total:
   default_units: dimensionless
   description:
   - Ratio of plasma pressure to magnetic pressure provided by the total magnetic field.
-  set_by:
-  - calc_beta_total
-  used_by:
-  - calc_beta_normalized
 bootstrap_fraction:
   default_units: dimensionless
   description:
   - Fraction of the plasma current due to the bootstrap current.
-  set_by:
-  - calc_bootstrap_fraction
-  used_by:
-  - calc_inductive_plasma_current
 breakdown_flux_consumption:
   default_units: weber
   description:
   - From a point model estimate given by :cite:`Sugihara`, this expression gives the
     required flux for ionization.
-  set_by:
-  - calc_breakdown_flux_consumption
-  used_by: []
 change_in_dilution:
   default_units: dimensionless
   description:
   - Change in the fuel-ion dilution, resolved per impurity species.
-  set_by:
-  - calc_zeff_and_dilution_due_to_impurities
-  used_by: []
 change_in_zeff:
   default_units: dimensionless
   description:
   - Change in the effective charge, resolved per impurity species.
-  set_by:
-  - calc_zeff_and_dilution_due_to_impurities
-  used_by: []
 confinement_power_scaling:
   default_units: null
   description:
   - A :class:`~cfspopcon.named_options.ConfinementPowerScaling` indicating which confinement
     mode power-threshold scaling to use.
-  set_by: []
-  used_by:
-  - calc_LH_transition_threshold_power
-  - calc_LI_transition_threshold_power
 confinement_threshold_scalar:
   default_units: dimensionless
   description:
   - Scalar value applied to the confinement threshold (:math:`P_{LH}` or :math:`P_{LI}`),
     used to study the effect of increasing or decreasing the threshold.
-  set_by: []
-  used_by:
-  - calc_LH_transition_threshold_power
-  - calc_LI_transition_threshold_power
 confinement_time_scalar:
   default_units: dimensionless
   description:
   - Usually denoted :math:`H`, scalar applied to the energy confinement time calculated
     from a scaling such that :math:`\tau_e = H \tau_{e,scaling}`.
-  set_by: []
-  used_by:
-  - calc_energy_confinement_time_from_scaling
-  - solve_energy_confinement_scaling_for_input_power
-  - switch_to_linearised_ohmic_confinement_below_threshold
-  - switch_to_L_mode_confinement_below_threshold
 core_impurity_species:
   default_units: null
   description:
   - A :class:`~cfspopcon.named_options.AtomicSpecies` indicating which species should
     be used as the core radiator
-  set_by: []
-  used_by:
-  - calc_core_seeded_impurity_concentration
 core_radiated_power_fraction:
   default_units: dimensionless
   description:
   - Fraction of input power radiated from the confined region before it reaches the
     separatrix.
-  set_by:
-  - calc_f_rad_core
-  used_by: []
 critical_alpha_MHD:
   default_units: dimensionless
   description:
   - Critical value of :math:`\alpha_{MHD}` used in the separatrix operational space.
-  set_by:
-  - calc_critical_alpha_MHD
-  used_by:
-  - calc_SepOS_LH_transition
-  - calc_SepOS_ideal_MHD_limit
-  - calc_SepOS_L_mode_density_limit
 current_relaxation_time:
   default_units: second
   description:
   - Time constant for the radial current diffusion.
-  set_by:
-  - calc_current_relaxation_time
-  used_by: []
 cylindrical_safety_factor:
   default_units: dimensionless
   description:
   - Analytical approximation of safety factor at :math:`\rho=0.95` (confusingly, still
     has some shaping corrections despite being called the 'cylindrical' safety factor).
-  set_by:
-  - calc_cylindrical_edge_safety_factor
-  used_by:
-  - calc_alpha_t
-  - calc_edge_collisionality
-  - calc_internal_inductivity
-  - calc_SepOS_ideal_MHD_limit
-  - calc_power_crossing_separatrix_in_electron_channel
 dilution:
   default_units: dimensionless
   description:
   - Fuel-species concentration as a fraction of the electron density :math:`n_{DT}/n_e`.
-  set_by:
-  - calc_zeff_and_dilution_due_to_impurities
-  used_by:
-  - calc_ion_density_peaking
-  - calc_jch_profiles
-  - calc_analytic_profiles
-  - calc_prf_profiles
-  - calc_peaking_and_analytic_profiles
-  - calc_peaking_and_prf_profiles
 edge_collisionality:
   default_units: dimensionless
   description:
   - Collisionality at the separatrix.
-  set_by:
-  - calc_edge_collisionality
-  used_by: []
 edge_impurity_concentration:
   default_units: dimensionless
   description:
   - Concentration of the edge radiator (impurity density relative to the electron
     density) in the edge.
-  set_by:
-  - calc_edge_impurity_concentration
-  used_by: []
 edge_impurity_concentration_in_core:
   default_units: dimensionless
   description:
   - Concentration of the edge-radiator impurity in the core, after applying a compression/enrichment
     factor.
-  set_by:
-  - calc_edge_impurity_concentration
-  used_by: []
 edge_impurity_enrichment:
   default_units: dimensionless
   description:
   - Ratio of concentration of the edge radiator in the core to in the edge, :math:`f_e
     = n_{edge}/n_{core}`.
-  set_by: []
-  used_by:
-  - calc_edge_impurity_concentration
 edge_impurity_species:
   default_units: null
   description:
   - A :class:`~cfspopcon.named_options.AtomicSpecies` indicating which species should
     be injected into the plasma to increase the power radiated from the confined region.
-  set_by: []
-  used_by:
-  - calc_edge_impurity_concentration
 effective_collisionality:
   default_units: dimensionless
   description:
   - Estimate of collisionality used for computing the expected density peaking.
-  set_by:
-  - calc_effective_collisionality
-  - calc_peaking_and_analytic_profiles
-  - calc_peaking_and_prf_profiles
-  used_by:
-  - calc_ion_density_peaking
-  - calc_electron_density_peaking
 ejima_coefficient:
   default_units: dimensionless
   description:
   - Empirical linear scaling factor of the product of major radius and plasma current
     at flattop correlated with resistive flux at start of flattop :math:`C_E`.
-  set_by: []
-  used_by:
-  - calc_resistive_flux
 electron_density_peaking:
   default_units: dimensionless
   description:
   - Ratio of the peak ion density to the volume-averaged electron density.
-  set_by:
-  - calc_electron_density_peaking
-  - calc_peaking_and_analytic_profiles
-  - calc_peaking_and_prf_profiles
-  used_by:
-  - calc_bootstrap_fraction
-  - calc_jch_profiles
-  - calc_jch_pedestal_peaking
-  - calc_analytic_profiles
-  - calc_prf_profiles
 electron_density_peaking_offset:
   default_units: dimensionless
   description:
   - Scalar offset of the electron density peaking relative to the density peaking
     scaling.
-  set_by: []
-  used_by:
-  - calc_electron_density_peaking
-  - calc_peaking_and_analytic_profiles
-  - calc_peaking_and_prf_profiles
 electron_density_pedestal_peaking:
   default_units: dimensionless
   description:
   - Ratio of the peak electron density to the pedestal electron density.
-  set_by:
-  - calc_jch_pedestal_peaking
-  used_by: []
 electron_density_profile:
   default_units: _1e19_per_cubic_metre
   description:
   - A 1D profile of the electron density as a function of :math:`\rho_{pol}`.
-  set_by:
-  - calc_jch_profiles
-  - calc_analytic_profiles
-  - calc_prf_profiles
-  - calc_peaking_and_analytic_profiles
-  - calc_peaking_and_prf_profiles
-  used_by:
-  - calc_bremsstrahlung_radiation
-  - calc_P_rad_hydrogen_bremsstrahlung
-  - calc_impurity_radiated_power_mavrin_coronal
-  - calc_impurity_radiated_power_mavrin_noncoronal
-  - calc_impurity_radiated_power_post_and_jensen
-  - calc_impurity_radiated_power_radas
-  - calc_impurity_radiated_power
-  - calc_synchrotron_radiation
-  - calc_intrinsic_radiated_power_from_core
-  - calc_core_seeded_impurity_concentration
 electron_temp_pedestal_peaking:
   default_units: dimensionless
   description:
   - Ratio of the peak electron temperature to the pedestal electron temperature.
-  set_by:
-  - calc_jch_pedestal_peaking
-  used_by: []
 electron_temp_profile:
   default_units: kiloelectron_volt
   description:
   - A 1D profile of the electron temperature as a function of :math:`\rho_{pol}`.
-  set_by:
-  - calc_jch_profiles
-  - calc_analytic_profiles
-  - calc_prf_profiles
-  - calc_peaking_and_analytic_profiles
-  - calc_peaking_and_prf_profiles
-  used_by:
-  - calc_bremsstrahlung_radiation
-  - calc_P_rad_hydrogen_bremsstrahlung
-  - calc_impurity_radiated_power_mavrin_coronal
-  - calc_impurity_radiated_power_mavrin_noncoronal
-  - calc_impurity_radiated_power_post_and_jensen
-  - calc_impurity_radiated_power_radas
-  - calc_impurity_radiated_power
-  - calc_synchrotron_radiation
-  - calc_intrinsic_radiated_power_from_core
-  - calc_core_seeded_impurity_concentration
 elongation_psi95:
   default_units: dimensionless
   description:
   - Usually denoted :math:`\kappa_{95}`, the elongation at the :math:`\psi_N=0.95`
     surface.
-  set_by:
-  - calc_elongation_at_psi95_from_areal_elongation
-  used_by:
-  - calc_areal_elongation_from_elongation_at_psi95
-  - calc_cylindrical_edge_safety_factor
-  - calc_critical_alpha_MHD
-  - calc_poloidal_sound_larmor_radius
 elongation_ratio_areal_to_psi95:
   default_units: dimensionless
   description:
   - Ratio of areal elongation to elongation at the :math:`\psi_N=0.95` surface, :math:`\kappa_{A}/\kappa_{95}`.
-  set_by: []
-  used_by:
-  - calc_areal_elongation_from_elongation_at_psi95
-  - calc_elongation_at_psi95_from_areal_elongation
 elongation_ratio_sep_to_areal:
   default_units: dimensionless
   description:
   - Ratio of separatrix elongation to areal elongation :math:`\kappa_{sep}/\kappa_A`.
-  set_by: []
-  used_by:
-  - calc_separatrix_elongation_from_areal_elongation
 energy_confinement_scaling:
   default_units: null
   description:
   - Which :math:`\tau_e` energy confinement scaling should be used. Should match a
     confinement scaling in `cfspopcon.formulas.energy_confinement::energy_confinement_scalings.yaml`.
-  set_by: []
-  used_by:
-  - calc_energy_confinement_time_from_scaling
-  - solve_energy_confinement_scaling_for_input_power
 energy_confinement_scaling_for_L_mode:
   default_units: null
   description:
   - Which :math:`\tau_e` energy confinement scaling should be used if :math:`P_{SOL}
     < P_{LH}`. Should match an L-mode confinement scaling in `cfspopcon.formulas.energy_confinement::energy_confinement_scalings.yaml`.
-  set_by: []
-  used_by:
-  - switch_to_L_mode_confinement_below_threshold
 energy_confinement_time:
   default_units: second
   description:
   - A characteristic time which gives the rate at which the plasma loses energy. In
     steady-state, :math:`\tau_e=W_p / P_in`.
-  set_by:
-  - calc_energy_confinement_time_from_scaling
-  - calc_energy_confinement_time_from_stored_energy_and_input_power
-  - solve_energy_confinement_scaling_for_input_power
-  - switch_to_linearised_ohmic_confinement_below_threshold
-  - switch_to_L_mode_confinement_below_threshold
-  - calc_power_balance_from_input_P_aux
-  used_by:
-  - calc_H98y2
-  - switch_to_linearised_ohmic_confinement_below_threshold
-  - switch_to_L_mode_confinement_below_threshold
-  - calc_triple_product
 external_flux:
   default_units: weber
   description:
@@ -556,187 +213,89 @@ external_flux:
     - Ip\frac{dL_e}{dt}`
   - Note, time-independent POPCON makes the simplification that :math:`L_e` is constant
     over the ramp-up.
-  set_by:
-  - calc_external_flux
-  used_by:
-  - calc_flux_needed_from_solenoid_over_rampup
 external_inductance:
   default_units: henry
   description:
   - The self-inductance associated with the LCFS of the plasma.
-  set_by:
-  - calc_external_inductance
-  used_by:
-  - calc_external_flux
-  - calc_invmu_0_dLedR
-  - calc_vertical_magnetic_field
 f_shaping:
   default_units: dimensionless
   description:
   - Shaping factor used to compute :math:`q_*`.
-  set_by:
-  - calc_f_shaping_for_qstar
-  used_by:
-  - calc_plasma_current_from_qstar
-  - calc_q_star_from_plasma_current
 fieldline_pitch_at_omp:
   default_units: dimensionless
   description:
   - The magnetic field pitch :math:`B_{tot} / B_{pol}` at the 'upstream' end of a
     flux tube in the scrape-off-layer, used to convert from poloidal to parallel heat
     flux density.
-  set_by:
-  - calc_fieldline_pitch_at_omp
-  used_by:
-  - calc_parallel_heat_flux_density
 flux_needed_from_CS_over_rampup:
   default_units: weber
   description:
   - The amount of flux needed from the CS over ramp up.
-  set_by:
-  - calc_flux_needed_from_solenoid_over_rampup
-  used_by:
-  - calc_max_flattop_duration
 fraction_of_external_power_coupled:
   default_units: dimensionless
   description:
   - 'Fraction of supplied external heating absorbed by the plasma: :math:`f_{coupled}=P_{external}
     / P_{launched}`.'
-  set_by: []
-  used_by:
-  - calc_auxiliary_power
-  - calc_input_power_for_fixed_auxiliary_power
-  - calc_power_balance_from_input_P_aux
 fraction_of_P_SOL_to_divertor:
   default_units: dimensionless
   description:
   - fraction of the total power going towards the most-loaded divertor target.
-  set_by: []
-  used_by:
-  - calc_parallel_heat_flux_density
-  - calc_power_crossing_separatrix_in_electron_channel
 fuel_ion_density_profile:
   default_units: _1e19_per_cubic_metre
   description:
   - A 1D profile of the fuel ion density as a function of :math:`\rho_{pol}`.
-  set_by:
-  - calc_jch_profiles
-  - calc_analytic_profiles
-  - calc_prf_profiles
-  - calc_peaking_and_analytic_profiles
-  - calc_peaking_and_prf_profiles
-  used_by:
-  - calc_fusion_power
 fusion_reaction:
   default_units: null
   description:
   - A `str` indicating which fusion reaction should be used, should match a class
     name in `cfspopcon.formulas.fusion_reaction.fusion_data`
-  set_by: []
-  used_by:
-  - calc_average_ion_mass
-  - calc_fusion_power
-  - calc_neutron_flux_to_walls
 fusion_triple_product:
   default_units: _1e20_per_cubic_metre * kiloelectron_volt * second
   description:
   - The product of the energy confinement time, the core ion temperature and core
     ion density, used as a metric for fusion performance.
-  set_by:
-  - calc_triple_product
-  used_by: []
 greenwald_density_limit:
   default_units: _1e19_per_cubic_metre
   description:
   - The highest volume-averaged density which can be achieved before a density-limit
     disruption is triggered.
-  set_by:
-  - calc_greenwald_density_limit
-  used_by:
-  - calc_greenwald_fraction
-  - calc_average_electron_density_from_greenwald_fraction
 greenwald_fraction:
   default_units: dimensionless
   description:
   - Ratio of the average electron density to the Greenwald density limit :math:`f_{G}=\bar
     n_e / n_G`.
-  set_by:
-  - calc_greenwald_fraction
-  used_by:
-  - calc_average_electron_density_from_greenwald_fraction
 H98y2:
   default_units: dimensionless
   description:
   - Ratio of energy confinement time to the ITER98y2 scaling
-  set_by:
-  - calc_H98y2
-  - calc_power_balance_from_input_P_aux
-  used_by: []
 heavier_fuel_species_fraction:
   default_units: dimensionless
   description:
   - Fraction of fuel ions which are the heavier species. i.e. for DT fusion, this
     is :math:`f_T = n_T/(n_T+n_D)`.
-  set_by: []
-  used_by:
-  - calc_average_ion_mass
-  - calc_fusion_power
-  - calc_neutron_flux_to_walls
 impurity_charge_state:
   default_units: dimensionless
   description:
   - The mean charge state of a non-fuel species.
-  set_by:
-  - calc_impurity_charge_state
-  - calc_zeff_and_dilution_due_to_impurities
-  used_by: []
 impurity_concentration:
   default_units: dimensionless
   description:
   - Concentration of each impurity species, relative to the electron density.
-  set_by:
-  - set_up_impurity_concentration_array
-  - calc_core_seeded_impurity_concentration
-  - calc_edge_impurity_concentration
-  used_by:
-  - calc_impurity_radiated_power_mavrin_coronal
-  - calc_impurity_radiated_power_mavrin_noncoronal
-  - calc_impurity_radiated_power_post_and_jensen
-  - calc_impurity_radiated_power_radas
-  - calc_impurity_radiated_power
-  - calc_intrinsic_radiated_power_from_core
-  - calc_core_seeded_impurity_concentration
-  - calc_edge_impurity_concentration
-  - calc_impurity_charge_state
-  - calc_zeff_and_dilution_due_to_impurities
 impurity_residence_time:
   default_units: second
   description:
   - The average time an impurity ion stays in the scrape-off-layer before it recycles
     on the wall.
-  set_by: []
-  used_by:
-  - calc_impurity_radiated_power_mavrin_noncoronal
 impurity_species:
   default_units: null
   description:
   - A :class:`~cfspopcon.named_options.AtomicSpecies` indicating which impurity to
     use for a calculation.
-  set_by: []
-  used_by:
-  - calc_impurity_radiated_power_mavrin_coronal
-  - calc_impurity_radiated_power_mavrin_noncoronal
-  - calc_impurity_radiated_power_post_and_jensen
 inductive_plasma_current:
   default_units: ampere
   description:
   - Plasma current driven by the central solenoid (i.e. excluding the contribution
     of the bootstrap current).
-  set_by:
-  - calc_inductive_plasma_current
-  used_by:
-  - calc_ohmic_power
-  - calc_loop_voltage
 internal_flux:
   default_units: weber
   description:
@@ -745,968 +304,395 @@ internal_flux:
     - \frac{Ip}{2}\frac{dL_i}{dt}`
   - Note, time-independent POPCON makes the simplification that :math:`L_i` is constant
     over the ramp-up.
-  set_by:
-  - calc_internal_flux
-  used_by:
-  - calc_flux_needed_from_solenoid_over_rampup
 internal_inductance:
   default_units: henry
   description:
   - The self-inductance of the plasma from the center to the plasma edge.
-  set_by:
-  - calc_internal_inductance_for_cylindrical
-  - calc_internal_inductance_for_noncylindrical
-  used_by:
-  - calc_internal_flux
 internal_inductivity:
   default_units: dimensionless
   description:
   - Also known as normalized internal inductance, for a general geometry, is :math:`\frac{\langle
     B^2_{\theta} \rangle _V}{\langle B_{\theta}(r=LCFS) \rangle}` but is approximated
     in POPCON for a cylindrical plasma.
-  set_by:
-  - calc_internal_inductivity
-  used_by:
-  - calc_internal_inductance_for_cylindrical
-  - calc_internal_inductance_for_noncylindrical
-  - calc_external_inductance
-  - calc_invmu_0_dLedR
-  - calc_vertical_magnetic_field
 intrinsic_impurity_concentration:
   default_units: dimensionless
   description:
   - Concentration of each intrinsic impurity species, relative to the electron density.
-  set_by: []
-  used_by:
-  - set_up_impurity_concentration_array
 inverse_aspect_ratio:
   default_units: dimensionless
   description:
   - Ratio of minor to major radius :math:`\epsilon= a / R_0`.
-  set_by:
-  - calc_inverse_aspect_ratio
-  used_by:
-  - calc_energy_confinement_time_from_scaling
-  - calc_H98y2
-  - solve_energy_confinement_scaling_for_input_power
-  - switch_to_linearised_ohmic_confinement_below_threshold
-  - switch_to_L_mode_confinement_below_threshold
-  - calc_plasma_volume
-  - calc_plasma_surface_area
-  - calc_minor_radius_from_inverse_aspect_ratio
-  - calc_normalised_collisionality
-  - calc_bootstrap_fraction
-  - calc_external_inductance
-  - calc_vertical_field_mutual_inductance
-  - calc_invmu_0_dLedR
-  - calc_vertical_magnetic_field
-  - calc_resistivity_trapped_enhancement
-  - calc_current_relaxation_time
-  - calc_f_shaping_for_qstar
-  - calc_plasma_current_from_qstar
-  - calc_q_star_from_plasma_current
-  - calc_lambda_q
-  - calc_lambda_q_with_eich_regression_15
-  - calc_power_balance_from_input_P_aux
 invmu_0_dLedR:
   default_units: dimensionless
   description:
   - :math:`\frac{1}{\mu_0}\frac{\partial L_e}{\partial R}` (eq.21 in :cite:`Barr_2018`)
     which is a part of the hoop force and therefore appears in the :term:`vertical_magnetic_field_equation`
     which counteracts the outward toroidal forces.
-  set_by:
-  - calc_invmu_0_dLedR
-  used_by:
-  - calc_vertical_magnetic_field
 ion_density_peaking:
   default_units: dimensionless
   description:
   - Ratio of the peak ion density to the volume-averaged ion density.
-  set_by:
-  - calc_ion_density_peaking
-  - calc_peaking_and_analytic_profiles
-  - calc_peaking_and_prf_profiles
-  used_by:
-  - calc_bootstrap_fraction
-  - calc_jch_profiles
-  - calc_jch_pedestal_peaking
-  - calc_analytic_profiles
-  - calc_prf_profiles
 ion_density_peaking_offset:
   default_units: dimensionless
   description:
   - Scalar offset of the ion density peaking relative to the density peaking scaling.
-  set_by: []
-  used_by:
-  - calc_ion_density_peaking
-  - calc_peaking_and_analytic_profiles
-  - calc_peaking_and_prf_profiles
 ion_density_pedestal_peaking:
   default_units: dimensionless
   description:
   - Ratio of the peak fuel ion density to the pedestal fuel ion density.
-  set_by:
-  - calc_jch_pedestal_peaking
-  used_by: []
 ion_heat_diffusivity:
   default_units: meter ** 2 / second
   description:
   - A heat diffusion constant which gives a heat flux corresponding to an ion temperature
     gradient.
-  set_by: []
-  used_by:
-  - calc_power_crossing_separatrix_in_ion_channel
 ion_temp_pedestal_peaking:
   default_units: dimensionless
   description:
   - Ratio of the peak ion temperature to the pedestal ion temperature.
-  set_by:
-  - calc_jch_pedestal_peaking
-  used_by: []
 ion_temp_profile:
   default_units: kiloelectron_volt
   description:
   - A 1D profile of the ion temperature as a function of :math:`\rho_{pol}`.
-  set_by:
-  - calc_jch_profiles
-  - calc_analytic_profiles
-  - calc_prf_profiles
-  - calc_peaking_and_analytic_profiles
-  - calc_peaking_and_prf_profiles
-  used_by:
-  - calc_fusion_power
-  - calc_neutron_flux_to_walls
 ion_to_electron_temp_ratio:
   default_units: dimensionless
   description:
   - Ratio of electron and ion temperatures, :math:`T_i/T_e`.
-  set_by: []
-  used_by:
-  - calc_alpha_t
-  - calc_edge_collisionality
-  - calc_average_ion_temp_from_temperature_ratio
-  - calc_SepOS_ideal_MHD_limit
 ionization_volume:
   default_units: meter ** 3
   description:
   - Volume available above the target for ionization
-  set_by:
-  - calc_ionization_volume_from_AUG
-  used_by:
-  - calc_reattachment_time_henderson
 ionization_volume_density_factor:
   default_units: dimensionless
   description:
   - factor that relates the target density to an averaged density across the ionization
     volume
-  set_by: []
-  used_by:
-  - calc_reattachment_time_henderson
 kappa_e0:
   default_units: watt / electron_volt ** 3.5 / meter
   description:
   - Electron heat conductivity constant, such that :math:`q_{e,\parallel,cond}=\kappa_{e0}T_{e}^{5/2}\nabla_\parallel
     T_e`.
-  set_by: []
-  used_by:
-  - calc_edge_impurity_concentration
-  - calc_separatrix_electron_temp
-  - two_point_model_fixed_fpow
-  - two_point_model_fixed_qpart
-  - two_point_model_fixed_tet
-  - calc_neutral_pressure_kallenbach
 kappa_ez:
   default_units: dimensionless
   description:
   - finite z correction factor to the electron heat conductivity.  per :cite:`Goldston_2017`
-  set_by: []
-  used_by:
-  - calc_neutral_pressure_kallenbach
 lambda_q:
   default_units: millimeter
   description:
   - The near-scrape-off-layer heat-flux-density decay length.
-  set_by:
-  - calc_lambda_q
-  - calc_lambda_q_with_brunner
-  - calc_lambda_q_with_eich_regression_9
-  - calc_lambda_q_with_eich_regression_14
-  - calc_lambda_q_with_eich_regression_15
-  used_by:
-  - calc_parallel_heat_flux_density
-  - calc_q_perp
-  - calc_neutral_pressure_kallenbach
 lambda_q_factor:
   default_units: dimensionless
   description:
   - A scaling factor :math:`C` which can be used to increase or decrease :math:`\lambda_q=C
     \lambda_{q,scaling}`.
-  set_by: []
-  used_by:
-  - calc_lambda_q
-  - calc_lambda_q_with_brunner
-  - calc_lambda_q_with_eich_regression_9
-  - calc_lambda_q_with_eich_regression_14
-  - calc_lambda_q_with_eich_regression_15
 lambda_q_scaling:
   default_units: null
   description:
   - A :class:`~cfspopcon.named_options.LambdaQScaling` indicating which scaling to
     use for calculating :term:`lambda_q`.
-  set_by: []
-  used_by:
-  - calc_lambda_q
 lengyel_overestimation_factor:
   default_units: dimensionless
   description:
   - A constant calibration factor applied to the impurity concentration calculated
     by the Lengyel model such that its value approximately matches the value calculated
     by higher fidelity modelling such as SOLPS.
-  set_by: []
-  used_by:
-  - calc_edge_impurity_concentration
 loop_voltage:
   default_units: volt
   description:
   - inductive loop voltage
-  set_by:
-  - calc_loop_voltage
-  used_by:
-  - calc_max_flattop_duration
-  - calc_ohmic_power
 magnetic_field_on_axis:
   default_units: tesla
   description:
   - Magnetic field at the geometric magnetic axis :math:`B_0 = BR / R0`.
-  set_by: []
-  used_by:
-  - calc_energy_confinement_time_from_scaling
-  - calc_H98y2
-  - solve_energy_confinement_scaling_for_input_power
-  - switch_to_linearised_ohmic_confinement_below_threshold
-  - switch_to_L_mode_confinement_below_threshold
-  - calc_synchrotron_radiation
-  - calc_intrinsic_radiated_power_from_core
-  - calc_PB_over_R
-  - calc_PBpRnSq
-  - calc_rho_star
-  - calc_plasma_current_from_qstar
-  - calc_q_star_from_plasma_current
-  - calc_cylindrical_edge_safety_factor
-  - calc_beta_toroidal
-  - calc_beta_normalized
-  - calc_troyon_limit
-  - calc_B_tor_omp
-  - calc_lambda_q
-  - calc_lambda_q_with_eich_regression_9
-  - calc_SepOS_LH_transition
-  - calc_SepOS_ideal_MHD_limit
-  - calc_SepOS_L_mode_density_limit
-  - calc_LH_transition_threshold_power
-  - calc_LI_transition_threshold_power
-  - calc_power_balance_from_input_P_aux
 major_radius:
   default_units: meter
   description:
   - The major radius of the geometric magnetic axis.
-  set_by: []
-  used_by:
-  - calc_energy_confinement_time_from_scaling
-  - calc_H98y2
-  - solve_energy_confinement_scaling_for_input_power
-  - switch_to_linearised_ohmic_confinement_below_threshold
-  - switch_to_L_mode_confinement_below_threshold
-  - calc_plasma_volume
-  - calc_plasma_surface_area
-  - calc_minor_radius_from_inverse_aspect_ratio
-  - calc_inverse_aspect_ratio
-  - calc_synchrotron_radiation
-  - calc_intrinsic_radiated_power_from_core
-  - calc_normalised_collisionality
-  - calc_alpha_t
-  - calc_edge_collisionality
-  - calc_PB_over_R
-  - calc_PBpRnSq
-  - calc_resistive_flux
-  - calc_poloidal_field_flux
-  - calc_breakdown_flux_consumption
-  - calc_internal_inductance_for_cylindrical
-  - calc_external_inductance
-  - calc_invmu_0_dLedR
-  - calc_vertical_magnetic_field
-  - calc_current_relaxation_time
-  - calc_loop_voltage
-  - calc_plasma_current_from_qstar
-  - calc_q_star_from_plasma_current
-  - calc_cylindrical_edge_safety_factor
-  - calc_effective_collisionality
-  - calc_B_tor_omp
-  - calc_parallel_heat_flux_density
-  - calc_q_perp
-  - calc_lambda_q
-  - calc_lambda_q_with_eich_regression_15
-  - calc_SepOS_LH_transition
-  - calc_SepOS_ideal_MHD_limit
-  - calc_SepOS_L_mode_density_limit
-  - calc_power_crossing_separatrix_in_electron_channel
-  - calc_LH_transition_threshold_power
-  - calc_power_balance_from_input_P_aux
-  - calc_peaking_and_analytic_profiles
-  - calc_peaking_and_prf_profiles
 max_flattop_duration:
   default_units: second
   description:
   - Given the loop voltage at flattop, and how much flux from the CS has been consumed
     over the ramp-up, this defines how long your flattop can be.
-  set_by:
-  - calc_max_flattop_duration
-  used_by: []
 maximum_P_LH_factor_for_P_SOL:
   default_units: dimensionless
   description:
   - If P_SOL is larger than this factor times the P_LH threshold, core impurities
     will be seeded to reduce P_SOL to th
-  set_by: []
-  used_by:
-  - calc_min_P_radiation_from_LH_factor
 mean_ion_charge_state:
   default_units: dimensionless
   description:
   - Mean charge state of the ions (:math:`n_e / \sum_j n_j`)
-  set_by: []
-  used_by:
-  - calc_alpha_t
-  - calc_edge_collisionality
 min_P_radiation:
   default_units: megawatt
   description:
   - The minimum amount of power which must be radiated from the confined region. If
     power radiated by the intrinsic impurities
   - is less than this, a core radiator will be injected until this level is reached.
-  set_by:
-  - calc_min_P_radiation_from_fraction
-  - calc_min_P_radiation_from_LH_factor
-  used_by:
-  - calc_P_radiation_from_core_seeded_impurity
 minimum_core_radiated_fraction:
   default_units: dimensionless
   description:
   - Minimum fraction of :math:`P_{in}` which should be radiated from the confined
     region, below which we will inject an additional core radiator to increase the
     radiated power up to this value.
-  set_by: []
-  used_by:
-  - calc_min_P_radiation_from_fraction
 minor_radius:
   default_units: meter
   description:
   - Horizontal minor radius of the plasma :math:`(R_{max,LCFS}-R_{min,LCFS})/2`
-  set_by:
-  - calc_minor_radius_from_inverse_aspect_ratio
-  used_by:
-  - calc_plasma_poloidal_circumference
-  - calc_inverse_aspect_ratio
-  - calc_vertical_minor_radius_from_elongation_and_minor_radius
-  - calc_synchrotron_radiation
-  - calc_intrinsic_radiated_power_from_core
-  - calc_greenwald_density_limit
-  - calc_rho_star
-  - calc_loop_voltage
-  - calc_cylindrical_edge_safety_factor
-  - calc_beta_poloidal
-  - calc_beta_normalized
-  - calc_troyon_limit
-  - calc_B_pol_omp
-  - calc_B_tor_omp
-  - calc_parallel_heat_flux_density
-  - calc_q_perp
-  - calc_poloidal_sound_larmor_radius
-  - calc_power_crossing_separatrix_in_electron_channel
-  - calc_LH_transition_threshold_power
 n_points_for_confined_region_profiles:
   default_units: null
   description:
   - The number of points to use for the confined region profiles.
-  set_by: []
-  used_by:
-  - calc_jch_profiles
-  - calc_jch_pedestal_peaking
-  - define_radial_grid
-  - calc_peaking_and_analytic_profiles
-  - calc_peaking_and_prf_profiles
 neoclassical_loop_resistivity:
   default_units: meter * ohm
   description:
   - Plasma loop neoclassical resistivity.
-  set_by:
-  - calc_neoclassical_loop_resistivity
-  used_by:
-  - calc_loop_voltage
 nesep_over_nebar:
   default_units: dimensionless
   description:
   - Ratio of the separatrix electron density to the volume-averaged electron density
     :math:`n_{e,sep} / \bar n_e`.
-  set_by: []
-  used_by:
-  - two_point_model_fixed_fpow
-  - two_point_model_fixed_qpart
-  - calc_separatrix_electron_density
 neutral_flux_density_factor:
   default_units: 1 / meter ** 2 / pascal / second
   description:
   - Conversion factor from neutral pressure at duct to neutral recycling flux at the
     target.  From :cite:`Kallenbach_2018`
-  set_by:
-  - calc_neutral_flux_density_factor
-  used_by:
-  - calc_neutral_pressure_kallenbach
 neutron_power_flux_to_walls:
   default_units: megawatt / meter ** 2
   description:
   - Neutron power per unit area to the wall.
-  set_by:
-  - calc_neutron_flux_to_walls
-  used_by: []
 neutron_rate:
   default_units: 1 / second
   description:
   - Number of neutrons produced per second.
-  set_by:
-  - calc_neutron_flux_to_walls
-  used_by: []
 normalized_beta:
   default_units: meter * percent * tesla / megaampere
   description:
   - Ratio of plasma pressure to magnetic pressure provided by the total magnetic field,
     normalized to :math:`\beta_{max} = I_MA / a B_0` (Troyon limit).
-  set_by:
-  - calc_beta_normalized
-  used_by: []
 normalized_inverse_temp_scale_length:
   default_units: dimensionless
   description:
   - Inverse normalized electron temperature gradient scale length :math:`a / ( T_e
     / \nabla T_e )`, which defines the shape of the :class:`~cfspopcon.named_options.ProfileForm.prf`
     profiles.
-  set_by: []
-  used_by:
-  - calc_prf_profiles
-  - calc_peaking_and_prf_profiles
 nu_star:
   default_units: dimensionless
   description:
   - The normalized collisionality.
-  set_by:
-  - calc_normalised_collisionality
-  used_by: []
 P_alpha:
   default_units: megawatt
   description:
   - Fusion power released as alpha particles integrated over the plasma volume.
-  set_by:
-  - calc_fusion_power
-  used_by:
-  - calc_auxiliary_power
-  - calc_input_power_for_fixed_auxiliary_power
-  - calc_power_balance_from_input_P_aux
 P_auxiliary_absorbed:
   default_units: megawatt
   description:
   - auxiliary heating absorbed by the plasma integrated over the plasma volume.
-  set_by:
-  - calc_auxiliary_power
-  - calc_input_power_for_fixed_auxiliary_power
-  - calc_power_balance_from_input_P_aux
-  used_by: []
 P_auxiliary_launched:
   default_units: megawatt
   description:
   - External heating supplied to the plasma (entering the volume, but not necessarily
     absorbed by the plasma) integrated over the plasma volume.
-  set_by:
-  - calc_auxiliary_power
-  used_by:
-  - calc_input_power_for_fixed_auxiliary_power
-  - calc_fusion_gain
-  - calc_power_balance_from_input_P_aux
 P_external:
   default_units: megawatt
   description:
   - External heating absorbed by the plasma (ohmic plus auxiliary) integrated over
     the plasma volume.
-  set_by:
-  - calc_auxiliary_power
-  - calc_input_power_for_fixed_auxiliary_power
-  - calc_power_balance_from_input_P_aux
-  used_by: []
 P_fusion:
   default_units: megawatt
   description:
   - Total power generated by fusion integrated over the plasma volume. For DT fusion,
     this is the sum of the power going to the alpha particles and to the neutrons.
-  set_by:
-  - calc_fusion_power
-  used_by:
-  - calc_fusion_gain
 P_in:
   default_units: megawatt
   description:
   - Total input power to the plasma. Sum of ohmic, auxiliary and alpha power.
-  set_by:
-  - calc_input_power_for_fixed_auxiliary_power
-  - solve_energy_confinement_scaling_for_input_power
-  - switch_to_linearised_ohmic_confinement_below_threshold
-  - switch_to_L_mode_confinement_below_threshold
-  - calc_power_balance_from_input_P_aux
-  used_by:
-  - calc_auxiliary_power
-  - calc_energy_confinement_time_from_scaling
-  - calc_energy_confinement_time_from_stored_energy_and_input_power
-  - calc_H98y2
-  - switch_to_linearised_ohmic_confinement_below_threshold
-  - switch_to_L_mode_confinement_below_threshold
-  - calc_f_rad_core
-  - require_P_rad_less_than_P_in
-  - calc_min_P_radiation_from_fraction
-  - calc_min_P_radiation_from_LH_factor
-  - calc_power_crossing_separatrix
 P_LH_thresh:
   default_units: megawatt
   description:
   - Power required to cross the L-H transition.
-  set_by:
-  - calc_LH_transition_threshold_power
-  used_by:
-  - calc_min_P_radiation_from_LH_factor
-  - calc_ratio_P_LH
 P_LI_thresh:
   default_units: megawatt
   description:
   - Power required to cross the L-I transition.
-  set_by:
-  - calc_LI_transition_threshold_power
-  used_by:
-  - calc_ratio_P_LI
 P_neutron:
   default_units: megawatt
   description:
   - Fusion power released as neutrons integrated over the plasma volume.
-  set_by:
-  - calc_fusion_power
-  used_by:
-  - calc_neutron_flux_to_walls
 P_ohmic:
   default_units: megawatt
   description:
   - Power deposited in the plasma due to resistive ohmic heating.
-  set_by:
-  - calc_ohmic_power
-  used_by:
-  - calc_auxiliary_power
-  - calc_input_power_for_fixed_auxiliary_power
-  - calc_fusion_gain
-  - calc_power_balance_from_input_P_aux
 P_rad_bremsstrahlung:
   default_units: megawatt
   description:
   - Power radiated due to Bremmsstrahlung from all species.
-  set_by:
-  - calc_bremsstrahlung_radiation
-  used_by: []
 P_rad_hydrogen_bremsstrahlung:
   default_units: megawatt
   description:
   - Power radiated due to Bremmsstrahlung from hydrogen.
-  set_by:
-  - calc_P_rad_hydrogen_bremsstrahlung
-  used_by: []
 P_rad_impurity:
   default_units: megawatt
   description:
   - Power radiated by impurities in the plasma.
-  set_by:
-  - calc_impurity_radiated_power_mavrin_coronal
-  - calc_impurity_radiated_power_mavrin_noncoronal
-  - calc_impurity_radiated_power_post_and_jensen
-  - calc_impurity_radiated_power_radas
-  - calc_impurity_radiated_power
-  used_by: []
 P_rad_synchrotron:
   default_units: megawatt
   description:
   - Power radiated due to synchrotron radiation.
-  set_by:
-  - calc_synchrotron_radiation
-  used_by: []
 P_radiation:
   default_units: megawatt
   description:
   - Power radiated from the confined region due to Bremmsstrahlung, synchrotron and
     impurity excitation-relaxation processes.
-  set_by:
-  - require_P_rad_less_than_P_in
-  - calc_intrinsic_radiated_power_from_core
-  - calc_P_radiation_from_core_seeded_impurity
-  used_by:
-  - calc_f_rad_core
-  - require_P_rad_less_than_P_in
-  - calc_P_radiation_from_core_seeded_impurity
-  - calc_power_crossing_separatrix
 P_radiation_from_core_seeded_impurity:
   default_units: megawatt
   description:
   - The power radiated by the core radiator.
-  set_by:
-  - calc_P_radiation_from_core_seeded_impurity
-  used_by:
-  - calc_core_seeded_impurity_concentration
 parallel_connection_length:
   default_units: meter
   description:
   - Parallel length (along a field-line) of a scrape-off-layer flux tube, from an
     'upstream' position (usually the outboard midplane) to the divertor target.
-  set_by: []
-  used_by:
-  - calc_separatrix_electron_temp
-  - two_point_model_fixed_fpow
-  - two_point_model_fixed_qpart
-  - two_point_model_fixed_tet
-  - calc_neutral_pressure_kallenbach
-  - calc_reattachment_time_henderson
 PB_over_R:
   default_units: megawatt * tesla / meter
   description:
   - :math:`P_{SOL}B_0/R`, a metric used to estimate how challenging heat exhaust will
     be.
-  set_by:
-  - calc_PB_over_R
-  used_by: []
 PBpRnSq:
   default_units: megawatt * tesla / _1e20_per_cubic_metre ** 2 / meter
   description:
   - :math:`P_{SOL}B_{pol}/(R n_{sep}^2)`, a metric used to estimate how challenging
     heat exhaust will be. This metric is approximately :math:`q_\parallel/n_{e,sep}^2`,
     which in the Lengyel model gives the impurity concentration required for detachment.
-  set_by:
-  - calc_PBpRnSq
-  used_by: []
 peak_electron_density:
   default_units: _1e19_per_cubic_metre
   description:
   - Peak electron density
-  set_by:
-  - calc_electron_density_peaking
-  - calc_peaking_and_analytic_profiles
-  - calc_peaking_and_prf_profiles
-  used_by:
-  - calc_peak_pressure
 peak_electron_temp:
   default_units: kiloelectron_volt
   description:
   - Peak electron temperature
-  set_by:
-  - calc_peak_electron_temp
-  - calc_temperature_peaking
-  - calc_peaking_and_analytic_profiles
-  - calc_peaking_and_prf_profiles
-  used_by:
-  - calc_peak_pressure
 peak_fuel_ion_density:
   default_units: _1e19_per_cubic_metre
   description:
   - Peak fuel ion density (i.e. product of fuel dilution, ion peaking factor and average
     electron density).
-  set_by:
-  - calc_ion_density_peaking
-  - calc_peaking_and_analytic_profiles
-  - calc_peaking_and_prf_profiles
-  used_by:
-  - calc_triple_product
-  - calc_peak_pressure
 peak_ion_temp:
   default_units: kiloelectron_volt
   description:
   - Peak ion temperature
-  set_by:
-  - calc_peak_ion_temp
-  - calc_temperature_peaking
-  - calc_peaking_and_analytic_profiles
-  - calc_peaking_and_prf_profiles
-  used_by:
-  - calc_triple_product
-  - calc_peak_pressure
 peak_pressure:
   default_units: pascal
   description:
   - Peak total pressure in the core.
-  set_by:
-  - calc_peak_pressure
-  used_by: []
 pedestal_width:
   default_units: dimensionless
   description:
   - Width of the edge pedestal in rho space.
-  set_by: []
-  used_by:
-  - calc_jch_profiles
-  - calc_jch_pedestal_peaking
 plasma_current:
   default_units: ampere
   description:
   - Current carried by the plasma :math:`I_p`.
-  set_by:
-  - calc_plasma_current_from_qstar
-  used_by:
-  - calc_energy_confinement_time_from_scaling
-  - calc_H98y2
-  - solve_energy_confinement_scaling_for_input_power
-  - switch_to_linearised_ohmic_confinement_below_threshold
-  - switch_to_L_mode_confinement_below_threshold
-  - calc_greenwald_density_limit
-  - calc_inductive_plasma_current
-  - calc_internal_flux
-  - calc_external_flux
-  - calc_resistive_flux
-  - calc_vertical_magnetic_field
-  - calc_q_star_from_plasma_current
-  - calc_cylindrical_edge_safety_factor
-  - calc_beta_poloidal
-  - calc_beta_normalized
-  - calc_troyon_limit
-  - calc_B_pol_omp
-  - calc_poloidal_sound_larmor_radius
-  - calc_LH_transition_threshold_power
-  - calc_LI_transition_threshold_power
-  - calc_power_balance_from_input_P_aux
 plasma_stored_energy:
   default_units: megajoule
   description:
   - Thermal energy in the plasma.
-  set_by:
-  - calc_plasma_stored_energy
-  used_by:
-  - calc_energy_confinement_time_from_stored_energy_and_input_power
-  - solve_energy_confinement_scaling_for_input_power
-  - switch_to_linearised_ohmic_confinement_below_threshold
-  - switch_to_L_mode_confinement_below_threshold
-  - calc_power_balance_from_input_P_aux
 plasma_volume:
   default_units: meter ** 3
   description:
   - Plasma volume inside the last-closed-flux-surface.
-  set_by:
-  - calc_plasma_volume
-  used_by:
-  - calc_plasma_stored_energy
-  - calc_fusion_power
-  - calc_bremsstrahlung_radiation
-  - calc_P_rad_hydrogen_bremsstrahlung
-  - calc_impurity_radiated_power_mavrin_coronal
-  - calc_impurity_radiated_power_mavrin_noncoronal
-  - calc_impurity_radiated_power_post_and_jensen
-  - calc_impurity_radiated_power_radas
-  - calc_impurity_radiated_power
-  - calc_synchrotron_radiation
-  - calc_intrinsic_radiated_power_from_core
-  - calc_core_seeded_impurity_concentration
-  - calc_internal_inductance_for_noncylindrical
-  - calc_ionization_volume_from_AUG
 poloidal_circumference:
   default_units: meter
   description:
   - Plasma poloidal circumference of the LCFS.
-  set_by:
-  - calc_plasma_poloidal_circumference
-  used_by:
-  - calc_internal_inductance_for_noncylindrical
 poloidal_field_flux:
   default_units: weber
   description:
   - The surface flux contribution from the vertical magnetic field required for radial
     force balance (which arises from the poloidal field coils).
-  set_by:
-  - calc_poloidal_field_flux
-  used_by:
-  - calc_flux_needed_from_solenoid_over_rampup
 poloidal_sound_larmor_radius:
   default_units: millimeter
   description:
   - The sound Larmor radius using the poloidal magnetic field.
-  set_by:
-  - calc_poloidal_sound_larmor_radius
-  used_by:
-  - calc_SepOS_LH_transition
-  - calc_SepOS_ideal_MHD_limit
-  - calc_power_crossing_separatrix_in_ion_channel
-  - calc_power_crossing_separatrix_in_electron_channel
 power_crossing_separatrix:
   default_units: megawatt
   description:
   - Power crossing the separatrix and entering the scrape-off-layer.
-  set_by:
-  - calc_power_crossing_separatrix
-  used_by:
-  - calc_PB_over_R
-  - calc_PBpRnSq
-  - calc_parallel_heat_flux_density
-  - calc_q_perp
-  - calc_lambda_q
-  - calc_lambda_q_with_eich_regression_9
-  - calc_lambda_q_with_eich_regression_15
-  - calc_ratio_P_LH
-  - calc_ratio_P_LI
 pumping_duct_neutral_pressure:
   default_units: pascal
   description:
   - Neutral pressure at the baratron position in pumping duct.
-  set_by:
-  - calc_neutral_pressure_kallenbach
-  used_by: []
 Q:
   default_units: dimensionless
   description:
   - Fusion power thermal gain factor.
-  set_by:
-  - calc_fusion_gain
-  used_by: []
 q_parallel:
   default_units: gigawatt / meter ** 2
   description:
   - The parallel heat flux density entering a scrape-off-layer flux tube.
-  set_by:
-  - calc_parallel_heat_flux_density
-  used_by:
-  - calc_edge_impurity_concentration
-  - calc_separatrix_electron_temp
-  - two_point_model_fixed_fpow
-  - two_point_model_fixed_qpart
-  - two_point_model_fixed_tet
-  - calc_neutral_pressure_kallenbach
 q_perp:
   default_units: megawatt / meter ** 2
   description:
   - The poloidal heat flux density entering a scrape-off-layer flux tube.
-  set_by:
-  - calc_q_perp
-  used_by: []
 q_star:
   default_units: dimensionless
   description:
   - Analytical approximation of safety factor at :math:`\rho=0.95`.
-  set_by:
-  - calc_q_star_from_plasma_current
-  used_by:
-  - calc_energy_confinement_time_from_scaling
-  - calc_H98y2
-  - solve_energy_confinement_scaling_for_input_power
-  - switch_to_linearised_ohmic_confinement_below_threshold
-  - switch_to_L_mode_confinement_below_threshold
-  - calc_normalised_collisionality
-  - calc_PBpRnSq
-  - calc_bootstrap_fraction
-  - calc_plasma_current_from_qstar
-  - calc_lambda_q
-  - calc_lambda_q_with_eich_regression_9
-  - calc_power_balance_from_input_P_aux
 radas_dir:
   default_units: null
   description:
   - A path to the `radas <https://github.com/cfs-energy/radas>`_ working directory.
-  set_by: []
-  used_by:
-  - read_atomic_data
 radas_version:
   default_units: null
   description:
   - Version of radas used to construct the atomic data files.
-  set_by:
-  - read_atomic_data
-  used_by: []
 radiated_power_method:
   default_units: null
   description:
   - A :class:`~cfspopcon.named_options.RadiationMethod` indicating how we should calculate
     the power radiated from the confined region.
-  set_by: []
-  used_by:
-  - calc_impurity_radiated_power
-  - calc_intrinsic_radiated_power_from_core
-  - calc_core_seeded_impurity_concentration
 radiated_power_scalar:
   default_units: dimensionless
   description:
   - An enhancement factor :math:`C` to modify the radiated power :math:`P_{rad} =
     C P_{rad,calculated}`.
-  set_by: []
-  used_by:
-  - calc_intrinsic_radiated_power_from_core
-  - calc_core_seeded_impurity_concentration
 ratio_of_divertor_to_duct_pressure:
   default_units: dimensionless
   description:
   - ratio between divertor neutral pressure and pressure at pumping duct
-  set_by: []
-  used_by:
-  - calc_neutral_pressure_kallenbach
 ratio_of_molecular_to_ion_mass:
   default_units: dimensionless
   description:
   - Ratio between neutral molecule mass and ion mass
-  set_by: []
-  used_by:
-  - calc_neutral_flux_density_factor
 ratio_of_P_SOL_to_P_LH:
   default_units: dimensionless
   description:
   - The ratio of the power crossing the separatrix to the LH transition threshold
     power.
-  set_by:
-  - calc_ratio_P_LH
-  used_by:
-  - switch_to_L_mode_confinement_below_threshold
 ratio_of_P_SOL_to_P_LI:
   default_units: dimensionless
   description:
   - The ratio of the power crossing the separatrix to the LI transition threshold
     power.
-  set_by:
-  - calc_ratio_P_LI
-  used_by: []
 ratio_of_separatrix_to_pedestal_density:
   default_units: dimensionless
   description:
   - Ratio of the separatrix electron density to the pedestal electron density :math:`n_{e,sep}
     / n_{e,ped}`.
-  set_by: []
-  used_by:
-  - calc_jch_profiles
-  - calc_jch_pedestal_peaking
 reattachment_time:
   default_units: second
   description:
   - Time duration for detachment front to reach the target in response to a transient.  Per
     :cite:`Henderson_2023`
-  set_by:
-  - calc_reattachment_time_henderson
-  used_by: []
 reference_electron_density:
   default_units: 1 / meter ** 3
   description:
   - A constant upstream electron density used when evaluating the :math:`L_Z` impurity
     radiation curve (due to the reasonably weak dependence of :math:`L_Z` on :math:`n_e`,
     this approximation shouldn't be too harmful).
-  set_by: []
-  used_by:
-  - calc_edge_impurity_concentration
 reference_ne_tau:
   default_units: second / meter ** 3
   description:
   - A constant :math:`n_e\tau` (upstream electron density times impurity residence
     time) used when evaluating the :math:`L_Z` impurity radiation curve.
-  set_by: []
-  used_by:
-  - calc_edge_impurity_concentration
 resistive_flux:
   default_units: weber
   description:
@@ -1714,232 +700,98 @@ resistive_flux:
     given that POPCON calculates this with the empirical :math:`C_E`, it may also
     hold information about flux induced coupling with the wall. :math:`\psi_{res}
     = C_E\mu_0R_0I_p`.
-  set_by:
-  - calc_resistive_flux
-  used_by:
-  - calc_flux_needed_from_solenoid_over_rampup
 resistivity_trapped_enhancement_method:
   default_units: null
   description:
   - A flag to indicate which method should be used when calculating the enhancement
     of resistivity due to trapped particles.
-  set_by: []
-  used_by:
-  - calc_resistivity_trapped_enhancement
 rho:
   default_units: dimensionless
   description:
   - The square-root of the normalized poloidal flux :math:`\rho_{pol}=\sqrt{\psi_N}`,
     used as a flux surface label.
-  set_by:
-  - calc_jch_profiles
-  - define_radial_grid
-  - calc_peaking_and_analytic_profiles
-  - calc_peaking_and_prf_profiles
-  used_by:
-  - calc_fusion_power
-  - calc_bremsstrahlung_radiation
-  - calc_P_rad_hydrogen_bremsstrahlung
-  - calc_impurity_radiated_power_mavrin_coronal
-  - calc_impurity_radiated_power_mavrin_noncoronal
-  - calc_impurity_radiated_power_post_and_jensen
-  - calc_impurity_radiated_power_radas
-  - calc_impurity_radiated_power
-  - calc_synchrotron_radiation
-  - calc_intrinsic_radiated_power_from_core
-  - calc_core_seeded_impurity_concentration
-  - calc_analytic_profiles
-  - calc_prf_profiles
 rho_star:
   default_units: dimensionless
   description:
   - The ratio of the sound Larmor radius to the major radius for the average ion temperature.
-  set_by:
-  - calc_rho_star
-  used_by: []
 safety_factor_on_axis:
   default_units: dimensionless
   description:
   - On-axis safety factor
-  set_by: []
-  used_by:
-  - calc_internal_inductivity
 separatrix_electron_density:
   default_units: _1e19_per_cubic_metre
   description:
   - The electron density at the 'upstream' end of a scrape-off-layer flux-tube (usually
     at the outboard midplane).
-  set_by:
-  - calc_separatrix_electron_density
-  used_by:
-  - calc_edge_impurity_concentration
-  - calc_alpha_t
-  - calc_edge_collisionality
-  - two_point_model_fixed_tet
-  - calc_neutral_pressure_kallenbach
-  - calc_SepOS_LH_transition
-  - calc_SepOS_ideal_MHD_limit
-  - calc_SepOS_L_mode_density_limit
-  - calc_power_crossing_separatrix_in_ion_channel
 separatrix_electron_temp:
   default_units: electron_volt
   description:
   - The electron temperature at the 'upstream' end of a scrape-off-layer flux-tube
     (usually at the outboard midplane).
-  set_by:
-  - calc_separatrix_electron_temp
-  - two_point_model_fixed_fpow
-  - two_point_model_fixed_qpart
-  - two_point_model_fixed_tet
-  used_by:
-  - calc_edge_impurity_concentration
-  - calc_alpha_t
-  - calc_edge_collisionality
-  - calc_jch_profiles
-  - calc_jch_pedestal_peaking
-  - calc_poloidal_sound_larmor_radius
-  - calc_SepOS_LH_transition
-  - calc_SepOS_ideal_MHD_limit
-  - calc_SepOS_L_mode_density_limit
-  - calc_power_crossing_separatrix_in_ion_channel
-  - calc_power_crossing_separatrix_in_electron_channel
 separatrix_elongation:
   default_units: dimensionless
   description:
   - Elongation of the last-closed-flux-surface :math:`(Z_{max,LCFS} - Z_{min,LCFS})
     / (R_{max,LCFS} - R_{min,LCFS})`.
-  set_by:
-  - calc_separatrix_elongation_from_areal_elongation
-  used_by:
-  - calc_energy_confinement_time_from_scaling
-  - calc_H98y2
-  - solve_energy_confinement_scaling_for_input_power
-  - switch_to_linearised_ohmic_confinement_below_threshold
-  - switch_to_L_mode_confinement_below_threshold
-  - calc_vertical_minor_radius_from_elongation_and_minor_radius
-  - calc_synchrotron_radiation
-  - calc_intrinsic_radiated_power_from_core
-  - calc_power_balance_from_input_P_aux
 separatrix_power_transient:
   default_units: megawatt
   description:
   - Transient increase to power crossing the separatrix.  Per :cite:`Henderson_2023`
-  set_by: []
-  used_by:
-  - calc_reattachment_time_henderson
 separatrix_triangularity:
   default_units: dimensionless
   description:
   - Separatrix triangularity (average of upper and lower triangularity).
-  set_by:
-  - calc_separatrix_triangularity_from_triangularity95
-  used_by:
-  - calc_energy_confinement_time_from_scaling
-  - calc_H98y2
-  - solve_energy_confinement_scaling_for_input_power
-  - switch_to_linearised_ohmic_confinement_below_threshold
-  - switch_to_L_mode_confinement_below_threshold
-  - calc_power_balance_from_input_P_aux
 SepOS_density_limit:
   default_units: dimensionless
   description:
   - Less than 1 if an L-mode is below the density limit, according to the separatrix
     operational space.
-  set_by:
-  - calc_SepOS_L_mode_density_limit
-  used_by: []
 SepOS_LH_transition:
   default_units: dimensionless
   description:
   - Less than 1 if in L-mode and greater than 1 if in H-mode, according to the separatrix
     operational space.
-  set_by:
-  - calc_SepOS_LH_transition
-  used_by: []
 SepOS_MHD_limit:
   default_units: dimensionless
   description:
   - Less than 1 if below the ideal MHD limit, according to the separatrix operational
     space.
-  set_by:
-  - calc_SepOS_ideal_MHD_limit
-  used_by: []
 sheath_heat_transmission_factor:
   default_units: dimensionless
   description:
   - Sheath heat transmission coefficient per equation 2.89 in :cite:`Stangeby_2000`
-  set_by: []
-  used_by:
-  - two_point_model_fixed_fpow
-  - two_point_model_fixed_qpart
-  - two_point_model_fixed_tet
-  - calc_neutral_pressure_kallenbach
 SOC_LOC_ratio:
   default_units: dimensionless
   description:
   - Ratio of the energy confinement time from the chosen saturated ohmic confinement
     (SOC) scaling and the chosen linear ohmic confinement (LOC) scaling.
-  set_by:
-  - switch_to_linearised_ohmic_confinement_below_threshold
-  used_by: []
 SOL_conduction_fraction:
   default_units: dimensionless
   description:
   - Fraction of power carried by heat conduction in the scrape-off-layer.
-  set_by: []
-  used_by:
-  - calc_separatrix_electron_temp
 SOL_momentum_loss_function:
   default_units: null
   description:
   - Fraction of momentum entering a scrape-off-layer flux tube which is lost before
     reaching the divertor target.
-  set_by: []
-  used_by:
-  - two_point_model_fixed_fpow
-  - two_point_model_fixed_qpart
-  - two_point_model_fixed_tet
-  - calc_neutral_pressure_kallenbach
 SOL_power_loss_fraction:
   default_units: dimensionless
   description:
   - Fraction of power entering a scrape-off-layer flux tube which is lost (radiated
     or cross-field transported) before reaching the divertor target.
-  set_by:
-  - two_point_model_fixed_qpart
-  - two_point_model_fixed_tet
-  used_by:
-  - calc_edge_impurity_concentration
-  - two_point_model_fixed_fpow
-  - calc_neutral_pressure_kallenbach
 spitzer_resistivity:
   default_units: meter * ohm
   description:
   - Plasma loop collisional resistivity.
-  set_by:
-  - calc_Spitzer_loop_resistivity
-  used_by:
-  - calc_neoclassical_loop_resistivity
 summed_impurity_density:
   default_units: _1e19_per_cubic_metre
   description:
   - Density of non-fuel ions.
-  set_by:
-  - calc_zeff_and_dilution_due_to_impurities
-  used_by:
-  - calc_plasma_stored_energy
 surface_area:
   default_units: meter ** 2
   description:
   - Area of the last-closed-flux-surface, i.e. the surface defined by toroidally revolving
     the poloidal last-closed-flux-surface.
-  set_by:
-  - calc_plasma_surface_area
-  used_by:
-  - calc_neutron_flux_to_walls
-  - calc_power_crossing_separatrix_in_ion_channel
-  - calc_LH_transition_threshold_power
-  - calc_LI_transition_threshold_power
 surface_inductance_coefficients:
   default_units: null
   description:
@@ -1947,241 +799,112 @@ surface_inductance_coefficients:
     paper on external flux which are used to fit analytic expressions, dependent on
     plasma geometry, to the external inductance and vertical field mutual inductance
     of the plasma.
-  set_by: []
-  used_by:
-  - calc_external_inductance
-  - calc_vertical_field_mutual_inductance
-  - calc_invmu_0_dLedR
-  - calc_vertical_magnetic_field
 sustainment_power_in_electron_channel:
   default_units: megawatt
   description:
   - The power in the electron channel required to maintain the electron temperature
     at the separatrix.
-  set_by:
-  - calc_power_crossing_separatrix_in_electron_channel
-  used_by: []
 sustainment_power_in_ion_channel:
   default_units: megawatt
   description:
   - The power in the ion channel required to maintain the ion temperature gradient
     at the separatrix.
-  set_by:
-  - calc_power_crossing_separatrix_in_ion_channel
-  used_by: []
 target_angle_of_incidence:
   default_units: degree
   description:
   - Angle of incidence between magnetic field vector and surface normal vector at
     divertor target.
-  set_by: []
-  used_by:
-  - calc_neutral_pressure_kallenbach
 target_electron_density:
   default_units: _1e19_per_cubic_metre
   description:
   - The electron density at the divertor target.
-  set_by:
-  - two_point_model_fixed_fpow
-  - two_point_model_fixed_qpart
-  - two_point_model_fixed_tet
-  used_by:
-  - calc_reattachment_time_henderson
 target_electron_flux:
   default_units: 1 / meter ** 2 / second
   description:
   - The rate of electrons per unit area reaching the divertor target.
-  set_by:
-  - two_point_model_fixed_fpow
-  - two_point_model_fixed_qpart
-  - two_point_model_fixed_tet
-  used_by: []
 target_electron_temp:
   default_units: electron_volt
   description:
   - The electron temperature at the divertor target.
-  set_by:
-  - two_point_model_fixed_fpow
-  - two_point_model_fixed_qpart
-  used_by:
-  - calc_edge_impurity_concentration
-  - calc_separatrix_electron_temp
-  - two_point_model_fixed_tet
-  - calc_neutral_pressure_kallenbach
-  - calc_power_crossing_separatrix_in_electron_channel
 target_gaussian_spreading:
   default_units: millimeter
   description:
   - Gaussian spreading coefficient, S, representing diffusive transport between x-point
     and divertor target
-  set_by: []
-  used_by:
-  - calc_neutral_pressure_kallenbach
 target_neutral_pressure:
   default_units: pascal
   description:
   - Neutral pressure at the divertor target.
-  set_by:
-  - calc_neutral_pressure_kallenbach
-  used_by:
-  - calc_reattachment_time_henderson
 target_q_parallel:
   default_units: gigawatt / meter ** 2
   description:
   - The parallel heat flux density at the divertor target.
-  set_by:
-  - two_point_model_fixed_fpow
-  - two_point_model_fixed_tet
-  used_by:
-  - two_point_model_fixed_qpart
 temp_scale_length_ratio:
   default_units: dimensionless
   description:
   - The ratio of the electron and ion temperature scale lengths at the separatrix
     :math:`T_i / T_e * \lambda_{T_e} / \lambda_{T_i} = L_{T_e} / L_{T_i}`.
-  set_by: []
-  used_by:
-  - calc_power_crossing_separatrix_in_ion_channel
 temperature_peaking:
   default_units: dimensionless
   description:
   - Ratio of the peak (electron or ion) temperature to the volume-averaged temperature.
-  set_by: []
-  used_by:
-  - calc_bootstrap_fraction
-  - calc_jch_profiles
-  - calc_jch_pedestal_peaking
-  - calc_analytic_profiles
-  - calc_prf_profiles
-  - calc_peak_electron_temp
-  - calc_peak_ion_temp
-  - calc_temperature_peaking
-  - calc_peaking_and_analytic_profiles
-  - calc_peaking_and_prf_profiles
 toroidal_flux_expansion:
   default_units: dimensionless
   description:
   - Ratio of the divertor target major radius to the 'upstream' (usually outboard
     midplane) major radius for the two point model :math:`R_{target} / R_{upstream}`.
-  set_by: []
-  used_by:
-  - two_point_model_fixed_fpow
-  - two_point_model_fixed_qpart
-  - two_point_model_fixed_tet
 total_flux_available_from_CS:
   default_units: weber
   description:
   - The amount of flux available from the central solenoid over the entire pulse.
-  set_by: []
-  used_by:
-  - calc_max_flattop_duration
 trapped_particle_fraction:
   default_units: dimensionless
   description:
   - Global average of the fraction of trapped electrons used in the calculation of
     global plasma resistivity.
-  set_by:
-  - calc_resistivity_trapped_enhancement
-  used_by:
-  - calc_neoclassical_loop_resistivity
 triangularity_psi95:
   default_units: dimensionless
   description:
   - Usually denoted :math:`\delta_{95}`, average of upper and lower triangularity
     at the :math:`\psi_N=0.95` surface.
-  set_by: []
-  used_by:
-  - calc_energy_confinement_time_from_scaling
-  - calc_H98y2
-  - solve_energy_confinement_scaling_for_input_power
-  - switch_to_linearised_ohmic_confinement_below_threshold
-  - switch_to_L_mode_confinement_below_threshold
-  - calc_separatrix_triangularity_from_triangularity95
-  - calc_f_shaping_for_qstar
-  - calc_cylindrical_edge_safety_factor
-  - calc_critical_alpha_MHD
-  - calc_poloidal_sound_larmor_radius
-  - calc_power_balance_from_input_P_aux
 triangularity_ratio_sep_to_psi95:
   default_units: dimensionless
   description:
   - Ratio of separatrix triangularity to triangularity at the :math:`psi_N=0.95` surface
     :math:`\delta_{sep}/\delta_{95}.`
-  set_by: []
-  used_by:
-  - calc_separatrix_triangularity_from_triangularity95
 troyon_max_beta:
   default_units: percent
   description:
   - The Troyon beta limit.
-  set_by:
-  - calc_troyon_limit
-  used_by: []
 two_point_model_error_nonconverged_error:
   default_units: null
   description:
   - Indicates whether the two-point-model should raise an error or return NaN if its
     iterative solver does not converge.
-  set_by: []
-  used_by:
-  - two_point_model_fixed_fpow
-  - two_point_model_fixed_qpart
 vertical_field_mutual_inductance:
   default_units: dimensionless
   description:
   - This unitless mutual-inductance quantity provides the coupling between the plasma
     surface and the vertical magnetic field.
-  set_by:
-  - calc_vertical_field_mutual_inductance
-  used_by:
-  - calc_poloidal_field_flux
 vertical_magnetic_field:
   default_units: tesla
   description:
   - Vertical magnetic field derived from the necessary force to balance the hoop force
     :math:`B_V`
-  set_by:
-  - calc_vertical_magnetic_field
-  used_by:
-  - calc_poloidal_field_flux
 vertical_magnetic_field_equation:
   default_units: null
   description:
   - Which vertical magnetic field equation to select from :cite:`mit&taka`, :cite:`Barr_2018`,
     :cite:`Jean`, :cite:`MFEF`
-  set_by: []
-  used_by:
-  - calc_vertical_magnetic_field
 vertical_minor_radius:
   default_units: meter
   description:
   - Vertical minor radius of the plasma :math:`(Z_{max,LCFS}-Z_{min,LCFS})/2`
-  set_by:
-  - calc_vertical_minor_radius_from_elongation_and_minor_radius
-  used_by: []
 wall_temperature:
   default_units: kelvin
   description:
   - Temperature of neutral gas at the wall
-  set_by: []
-  used_by:
-  - calc_neutral_flux_density_factor
 z_effective:
   default_units: dimensionless
   description:
   - The "effective charge" of the ions, defined as :math:`\sum_j Z_j^2 n_j / n_e`.
-  set_by:
-  - calc_zeff_and_dilution_due_to_impurities
-  used_by:
-  - calc_bremsstrahlung_radiation
-  - calc_intrinsic_radiated_power_from_core
-  - calc_normalised_collisionality
-  - calc_alpha_t
-  - calc_edge_collisionality
-  - calc_bootstrap_fraction
-  - calc_neoclassical_loop_resistivity
-  - calc_current_relaxation_time
-  - calc_effective_collisionality
-  - calc_power_crossing_separatrix_in_electron_channel
-  - calc_peaking_and_analytic_profiles
-  - calc_peaking_and_prf_profiles

--- a/docs/doc_sources/understanding_algorithms.ipynb
+++ b/docs/doc_sources/understanding_algorithms.ipynb
@@ -24,8 +24,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/Users/tbody/Projects/cfspopcon\n",
-      "Running in /Users/tbody/Projects/cfspopcon\n"
+      "/Users/tbody/Projects/cfspopcon-public\n",
+      "Running in /Users/tbody/Projects/cfspopcon-public\n"
      ]
     }
    ],
@@ -162,7 +162,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.PathCollection at 0x1175cdfa0>"
+       "<matplotlib.collections.PathCollection at 0x1154cafc0>"
       ]
      },
      "execution_count": 4,
@@ -336,7 +336,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.PathCollection at 0x117622570>"
+       "<matplotlib.collections.PathCollection at 0x1156c2ea0>"
       ]
      },
      "execution_count": 9,
@@ -383,7 +383,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.PathCollection at 0x117683b90>"
+       "<matplotlib.collections.PathCollection at 0x1158788c0>"
       ]
      },
      "execution_count": 10,
@@ -456,7 +456,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.QuadMesh at 0x11794a420>"
+       "<matplotlib.collections.QuadMesh at 0x11588f4d0>"
       ]
      },
      "execution_count": 12,
@@ -620,7 +620,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.QuadMesh at 0x1179de810>"
+       "<matplotlib.collections.QuadMesh at 0x1158f7590>"
       ]
      },
      "execution_count": 17,
@@ -717,7 +717,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Missing input parameters [areal_elongation].\n"
+      "Missing input parameters [areal_elongation].\n",
+      "'areal_elongation' is set by [calc_areal_elongation_from_elongation_at_psi95]: add one to your algorithms list, or provide 'areal_elongation' as an input.\n"
      ]
     }
    ],
@@ -742,7 +743,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/var/folders/x2/fhfghwm566d83ws71kgzj86c0000gp/T/ipykernel_55289/772097659.py:8: UserWarning: Unused input parameters [something_unused].\n",
+      "/var/folders/x2/fhfghwm566d83ws71kgzj86c0000gp/T/ipykernel_39366/772097659.py:8: UserWarning: Unused input parameters [something_unused].\n",
       "  Algorithm.get_algorithm(\"my_composite_algorithm\").validate_inputs(ds)\n"
      ]
     },

--- a/tests/test_algorithms_class.py
+++ b/tests/test_algorithms_class.py
@@ -346,6 +346,26 @@ def test_registry_indexing():
         registry["not_a_registered_algorithm_name"]
 
 
+def test_missing_input_hint_names_setters():
+    def needs_volume(plasma_volume):
+        return {"probe_out": plasma_volume}
+
+    alg = Algorithm(function=needs_volume, return_keys=["probe_out"], skip_registration=True)
+    with pytest.raises(RuntimeError, match=r"'plasma_volume' is set by \[calc_plasma_volume\]"):
+        alg.validate_inputs({}, raise_error_on_missing_inputs=True)
+
+
+def test_unused_input_hint_suggests_close_match(how_many_birds, how_many_animals):
+    count_the_farm = how_many_birds + how_many_animals
+    with pytest.raises(RuntimeError, match="did you mean 'things_that_baa'"):
+        count_the_farm.validate_inputs(dict(things_that_quack=1, things_that_baaa=4))
+
+
+def test_no_hint_without_a_setter_or_close_match(how_many_birds):
+    with pytest.raises(RuntimeError, match=r"^Missing input parameters \[things_that_quack\].$"):
+        how_many_birds.validate_inputs({}, raise_error_on_missing_inputs=True)
+
+
 def test_registry_queries():
     """algorithms_setting/algorithms_using answer from the live registry, sorted."""
     assert algorithms_setting("plasma_volume") == ["calc_plasma_volume"]

--- a/tests/test_algorithms_class.py
+++ b/tests/test_algorithms_class.py
@@ -4,7 +4,7 @@ from typing import Any
 import pytest
 import xarray as xr
 
-from cfspopcon.algorithm_class import Algorithm, CompositeAlgorithm, registry
+from cfspopcon.algorithm_class import Algorithm, CompositeAlgorithm, algorithms_setting, algorithms_using, registry
 from cfspopcon.unit_handling import ureg
 
 
@@ -344,6 +344,29 @@ def test_registry_indexing():
         registry[123]
     with pytest.raises(KeyError):
         registry["not_a_registered_algorithm_name"]
+
+
+def test_registry_queries():
+    """algorithms_setting/algorithms_using answer from the live registry, sorted."""
+    assert algorithms_setting("plasma_volume") == ["calc_plasma_volume"]
+    users = algorithms_using("plasma_volume")
+    assert "calc_fusion_power" in users
+    assert users == sorted(users)
+    assert algorithms_setting("not_a_registered_variable") == []
+
+
+def test_registry_queries_exclude_composites():
+    """A registered composite never appears in a query answer; its components do."""
+    name = "_query_probe_composite"
+    component = Algorithm.get_algorithm("calc_plasma_volume")
+    Algorithm.instances.pop(name, None)
+    try:
+        CompositeAlgorithm([component], name=name, register=True)
+        assert name not in algorithms_setting("plasma_volume")
+        assert name not in algorithms_using("major_radius")
+        assert "calc_plasma_volume" in algorithms_setting("plasma_volume")
+    finally:
+        Algorithm.instances.pop(name, None)
 
 
 def test_composite_registration_collision_and_override():

--- a/tests/test_algorithms_class.py
+++ b/tests/test_algorithms_class.py
@@ -70,6 +70,7 @@ def test_composite_signature(how_many_birds, how_many_animals):
 
 
 def test_dummy_algorithm(how_many_birds, BIRDS):
+    assert how_many_birds.name == "count_birds"
     assert how_many_birds.return_keys == BIRDS
     assert how_many_birds.input_keys == ["things_that_quack", "things_that_cluck"]
     assert how_many_birds.required_input_keys == ["things_that_quack"]
@@ -98,6 +99,7 @@ def test_dummy_algorithm(how_many_birds, BIRDS):
 def test_dummy_composite_algorithm(how_many_birds, BIRDS, how_many_animals, ANIMALS):
     count_the_farm = how_many_birds + how_many_animals
 
+    assert count_the_farm.name is None
     assert set(count_the_farm.return_keys) == set(BIRDS).union(set(ANIMALS))
     assert set(count_the_farm.input_keys) == {"things_that_quack", "things_that_cluck", "things_that_baa", "new_chickens_per_count"}
     assert set(count_the_farm.required_input_keys) == {"things_that_quack", "things_that_baa"}
@@ -264,12 +266,12 @@ def test_get_algorithm():
     # Pass in Algorithm Enums
     for key in Algorithm.algorithms():
         alg = Algorithm.get_algorithm(key)
-        assert alg._name in [f"run_{key}", key, "<lambda>"]
+        assert alg.name in [f"run_{key}", key, "<lambda>"]
 
     # Pass in strings instead
     for key in Algorithm.algorithms():
         alg = Algorithm.get_algorithm(key)
-        assert alg._name in [f"run_{key}", key, "<lambda>"]
+        assert alg.name in [f"run_{key}", key, "<lambda>"]
 
 
 def test_blank_algorithm():
@@ -335,8 +337,8 @@ def test_registry_indexing():
     assert isinstance(registry[tuple(names)], CompositeAlgorithm)
 
     # A composite runs its algorithms in the order the names are given.
-    assert [alg._name for alg in registry[names].algorithms] == names
-    assert [alg._name for alg in registry[names[::-1]].algorithms] == names[::-1]
+    assert [alg.name for alg in registry[names].algorithms] == names
+    assert [alg.name for alg in registry[names[::-1]].algorithms] == names[::-1]
 
     with pytest.raises(TypeError, match="name .str. or a list"):
         registry[123]

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -126,6 +126,19 @@ def test_plugin_algorithms_appear_in_registry_queries(tmp_path):
     assert "calc_test_plugin_metric" in algorithms_using("average_electron_density")
 
 
+def test_missing_input_hint_names_plugin_algorithm(tmp_path):
+    """The missing-input hint can name a plugin's algorithm as the setter."""
+    name = write_plugin(tmp_path, "popcon_test_plugin_hint", OK_PLUGIN)
+    register_plugin(name)
+
+    def needs_metric(test_plugin_metric):
+        return {"probe_out": test_plugin_metric}
+
+    alg = Algorithm(function=needs_metric, return_keys=["probe_out"], skip_registration=True)
+    with pytest.raises(RuntimeError, match=r"'test_plugin_metric' is set by \[calc_test_plugin_metric\]"):
+        alg.validate_inputs({}, raise_error_on_missing_inputs=True)
+
+
 def test_register_plugin_is_idempotent(tmp_path):
     """Registering the same plugin twice returns the original report."""
     name = write_plugin(tmp_path, "popcon_test_plugin_twice", OK_PLUGIN)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -496,9 +496,6 @@ file_declared_metric:
   default_units: meter**2
   description:
   - An area declared by the plugin's own variables file
-  set_by:
-  - calc_file_declared_metric
-  used_by: []
 file_declared_selector:
   default_units: null
   description:

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -7,6 +7,7 @@ from textwrap import dedent
 import pytest
 import xarray as xr
 import yaml
+from click.testing import CliRunner
 from utils.throwaway_packages import forget_packages, write_package
 
 import cfspopcon
@@ -19,7 +20,11 @@ from cfspopcon import (
     register_plugin,
     register_plugins,
 )
+
+# Imported here, not inside the CLI test: restore_registries evicts any package first imported
+# during a test, and evicting cfspopcon.cli would take the whole of cfspopcon with it.
 from cfspopcon.algorithm_class import _pending_composites, pending_composites, restore_registry, registered_algorithms
+from cfspopcon.cli import write_algorithms_yaml
 from cfspopcon.plugins import _failed_registrations, _successful_registrations
 from cfspopcon.unit_handling import Quantity, ureg
 from cfspopcon.unit_handling.default_units import default_unit, default_units_map, extend_default_units_map, reset_default_units
@@ -137,6 +142,18 @@ def test_missing_input_hint_names_plugin_algorithm(tmp_path):
     alg = Algorithm(function=needs_metric, return_keys=["probe_out"], skip_registration=True)
     with pytest.raises(RuntimeError, match=r"'test_plugin_metric' is set by \[calc_test_plugin_metric\]"):
         alg.validate_inputs({}, raise_error_on_missing_inputs=True)
+
+
+def test_popcon_algorithms_lists_plugin_algorithms(tmp_path):
+    """popcon_algorithms --plugin adds the plugin's algorithms to the listing."""
+    name = write_plugin(tmp_path, "popcon_test_plugin_listing", OK_PLUGIN)
+    output = tmp_path / "algs.yaml"
+
+    assert CliRunner().invoke(write_algorithms_yaml, ["-o", str(output)], catch_exceptions=False).exit_code == 0
+    assert "calc_test_plugin_metric" not in yaml.safe_load(output.read_text())
+
+    assert CliRunner().invoke(write_algorithms_yaml, ["-o", str(output), "--plugin", name], catch_exceptions=False).exit_code == 0
+    assert "calc_test_plugin_metric" in yaml.safe_load(output.read_text())
 
 
 def test_register_plugin_is_idempotent(tmp_path):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -10,7 +10,15 @@ import yaml
 from utils.throwaway_packages import forget_packages, write_package
 
 import cfspopcon
-from cfspopcon import Algorithm, CompositeAlgorithm, PluginClashError, register_plugin, register_plugins
+from cfspopcon import (
+    Algorithm,
+    CompositeAlgorithm,
+    PluginClashError,
+    algorithms_setting,
+    algorithms_using,
+    register_plugin,
+    register_plugins,
+)
 from cfspopcon.algorithm_class import _pending_composites, pending_composites, restore_registry, registered_algorithms
 from cfspopcon.plugins import _failed_registrations, _successful_registrations
 from cfspopcon.unit_handling import Quantity, ureg
@@ -107,6 +115,15 @@ def test_registered_algorithm_runs_in_composite_chain(tmp_path):
     )
 
     assert dataset["test_plugin_metric"].item() == pytest.approx(25.0 / 85.235, rel=1e-3)
+
+
+def test_plugin_algorithms_appear_in_registry_queries(tmp_path):
+    """The registry queries include a plugin's algorithms once it is registered."""
+    name = write_plugin(tmp_path, "popcon_test_plugin_queries", OK_PLUGIN)
+    register_plugin(name)
+
+    assert "calc_test_plugin_metric" in algorithms_setting("test_plugin_metric")
+    assert "calc_test_plugin_metric" in algorithms_using("average_electron_density")
 
 
 def test_register_plugin_is_idempotent(tmp_path):

--- a/tests/utils/variable_consistency_checker.py
+++ b/tests/utils/variable_consistency_checker.py
@@ -15,14 +15,14 @@ from cfspopcon.unit_handling import Quantity
 
 class VariableConsistencyChecker:
     # KNOWN HAZARD, not yet guarded. This scans *all* of Algorithm.instances and writes the result to
-    # cfspopcon's own variables.yaml. If a plugin has been registered in the same process, its
-    # variables are treated as cfspopcon's: `--run` adds them to variables.yaml, with default_units
-    # None, so the plugin's real units are discarded too. Verified by probe, not by test.
+    # cfspopcon's own variables.yaml. If a plugin has been registered in the same process, `--run`
+    # adds its variable keys to variables.yaml, with default_units None, so the plugin's real units
+    # are discarded too. Verified by probe, not by test.
     #
     # Nothing triggers it today, because check_variables_cli below calls only
     # discover_builtin_algorithms(), and the pre-commit hook runs in a clean environment. It is one
-    # stray cfspopcon.register_plugin call away. See PLUGINS_IDEA.md ("E7") for the fix under
-    # discussion: drop set_by/used_by, and stop the checker adding keys it was not given.
+    # stray cfspopcon.register_plugin call away. The remaining fix is to stop the checker adding
+    # keys it was not given.
     """A class for comparing the keys in algorithms, default units and the physics glossary."""
 
     def __init__(self) -> None:
@@ -163,21 +163,9 @@ class VariableConsistencyChecker:
             exit(0) if success else exit(1)
 
         all_keys = sorted((self.variable_keys - unused_variable_keys) | unlisted_args, key=str.lower)
-        algs_using_variable: dict[str, list[str]] = {key: [] for key in all_keys}
-        algs_setting_variable: dict[str, list[str]] = {key: [] for key in all_keys}
-        for alg in Algorithm.instances.values():
-            # A composite can reach a variable through several of its members;
-            # dedupe so each algorithm is listed once per variable.
-            for key in set(alg.input_keys):
-                algs_using_variable[key].append(alg._name)  # type:ignore[arg-type]
-            for key in set(alg.return_keys):
-                algs_setting_variable[key].append(alg._name)  # type:ignore[arg-type]
 
         new_variables_dict = dict()
         for key in all_keys:
-            used_by = algs_using_variable[key]
-            set_by = algs_setting_variable[key]
-
             if key in self.variables_dict:
                 default_units = self.variables_dict[key]["default_units"]
                 if default_units is not None:
@@ -197,8 +185,6 @@ class VariableConsistencyChecker:
             new_variables_dict[key] = dict(
                 default_units=default_units,
                 description=description,
-                set_by=set_by,
-                used_by=used_by,
             )
 
         with as_file(files("cfspopcon").joinpath("variables.yaml")) as filepath:


### PR DESCRIPTION
Stacked on #155 (the stack is #153 → #154 → #155 → this). Follow-ups from building a real plugin against #155, plus the removal of `set_by`/`used_by` agreed there.

## What this adds

- **Registry queries.** `algorithms_setting(var)` / `algorithms_using(var)` answer "which algorithms set / use this variable?" from the live registry — plugin-aware by construction, sorted, and leaf algorithms only (every composite containing a setter would repeat it, and each contains a plain `Algorithm` which sets the variable anyway). Exported alongside `registered_algorithms`. Also a public `.name` property on `Algorithm` and `CompositeAlgorithm` (`str | None` for unnamed composites), replacing cross-object `_name` reads.

- **`variables.yaml` drops `set_by`/`used_by`** (2187 → 910 lines, a pure-deletion diff generated by `variable_consistency_checker.py --run`, not edited). Nothing read them — they were write-only bookkeeping, the bulk of the file, and the sole cause of its reordering churn, since their list order followed discovery order. The queries above are the live replacement, and the file parsed at import time shrinks 58%. This does **not** close E7 on its own: the checker still invents an entry for any key it is not given; its hazard comment now says exactly that.

- **`validate_inputs` hints.** A missing input which some registered algorithm sets earns a line naming the setters (`'areal_elongation' is set by [calc_areal_elongation_from_elongation_at_psi95]: add one to your algorithms list, or provide 'areal_elongation' as an input.`), and an unused input close to one of the algorithm's own inputs earns `Unused parameter 'P_fus': did you mean 'P_fusion'?`. The near-miss check runs in the typo direction — a typo surfaces as an *unused* key while the intended name surfaces as missing — and matches against the algorithm's `input_keys`, so it never suggests a variable the selected algorithms cannot consume and is plugin-aware for free. Both bracket lists are now sorted (previously nondeterministic set order); a key with no setter and no close match keeps today's message exactly. The notebook's stored missing-input output was re-executed to show the hint.

- **`popcon_algorithms --plugin`** (repeatable) registers plugin packages before writing the listing, so plugin algorithms appear alongside the builtins.

## Verification

Bare `pytest -q` **209 passed** (includes the doc notebooks); `regression_results.py` then `pytest tests/test_regression_against_cases.py` (5 passed, no leftover diff); `ruff check`/`ruff format --check` clean; `mypy cfspopcon` at the 58-errors-in-5-files baseline; `variable_consistency_checker.py --run` converges (byte-identical on repeat) with zero `physics_glossary.rst` diff; docs `-n -W`, doctest and linkcheck clean.

## Notes for review

- Composite exclusion is a judgement call: a query answer listing `calc_plasma_volume` plus every registered composite containing it buries the useful name. No information is lost — any composite providing a variable contains a leaf which provides it. An `include_composites` flag can be added compatibly if wanted.
- The CLI test imports `cfspopcon.cli` at module level deliberately: the plugin-test fixture evicts any package first imported *during* a test, and evicting `cfspopcon.cli` takes the whole of cfspopcon's module state with it (a comment in the test file records this constraint).
