### PR TITLE
Point-file JSON validity, interactive-plot readout fix, and plot-style docs

### DIFF
--- a/cfspopcon/file_io.py
+++ b/cfspopcon/file_io.py
@@ -120,6 +120,17 @@ def read_dataset_from_netcdf(filepath: Path) -> xr.Dataset:
 # floats lead to a large, meaningless diff of the reference JSON files.
 
 
+def _rounded_float_repr(x: float) -> str:
+    """Format to 6 significant figures, keeping the result a valid JSON number.
+
+    '#' keeps the decimal point, but a value whose integer part uses all 6 figures ends in a bare
+    trailing point (e.g. '732029.'), which json cannot read back; one more significant figure puts
+    a digit after the point instead.
+    """
+    formatted = f"{x:#.6g}"
+    return f"{x:#.7g}" if formatted.endswith(".") else formatted
+
+
 class _RoundingFloat(float):
     """A modified version of the 'float' built-in, with a modified __repr__.
 
@@ -128,7 +139,7 @@ class _RoundingFloat(float):
     From: https://stackoverflow.com/questions/54370322/how-to-limit-the-number-of-float-digits-jsonencoder-produces
     """
 
-    __repr__ = staticmethod(lambda x: f"{x:#.6g}")  # type:ignore[assignment,unused-ignore]
+    __repr__ = staticmethod(_rounded_float_repr)  # type:ignore[assignment,unused-ignore]
 
 
 class _ModifyJSONFloatRepr:

--- a/cfspopcon/plotting/coordinate_formatter.py
+++ b/cfspopcon/plotting/coordinate_formatter.py
@@ -13,9 +13,13 @@ import xarray as xr
 class CoordinateFormatter:
     """Data storage object used for providing a coordinate formatter."""
 
-    def __init__(self, array: xr.DataArray):  # pragma: nocover
-        """Stores the data required for grid lookup."""
-        self.array = array
+    def __init__(self, array: xr.DataArray):
+        """Stores the data required for grid lookup, moving any units into the attrs.
+
+        Without the dequantify, item() on a unitful field returns a pint Quantity, and float() on
+        one raises a DimensionalityError on every mouse move.
+        """
+        self.array = array.pint.dequantify(format="~P")
 
     def __call__(self, mouse_x, mouse_y):  # pragma: nocover
         """Returns a string which gives the field value at the queried mouse position."""
@@ -23,4 +27,6 @@ class CoordinateFormatter:
 
         mouse_z = float(self.array.sel(lookup, method="nearest").item())
 
-        return f"x={mouse_x:f}, y={mouse_y:f}, z={mouse_z:f}"
+        readout = f"x={mouse_x:f}, y={mouse_y:f}, z={mouse_z:f}"
+        units = self.array.attrs.get("units", "")
+        return f"{readout} [{units}]" if units else readout

--- a/docs/doc_sources/plot_styles.rst
+++ b/docs/doc_sources/plot_styles.rst
@@ -1,0 +1,97 @@
+.. _plotstyles:
+
+Plot Styles
+************
+
+Each entry in an input file's ``plots`` section names a yaml "plot style" file, which
+``popcon`` renders with ``cfspopcon.plotting.make_plot``. The committed examples are
+``example_cases/SPARC_PRD/plot_popcon.yaml`` (a filled POPCON on the input grid) and
+``plot_remapped.yaml`` (the same, remapped onto computed variables). This page lists the keys
+those files may use.
+
+Top-level keys
+====================
+
+``type``
+  Only ``popcon`` is implemented.
+``figsize``
+  ``[width, height]`` in inches.
+``show_dpi``
+  Figure resolution.
+``legend_loc``
+  A matplotlib legend location string; defaults to ``best``.
+``coords`` or ``new_coords``
+  Exactly one of the two — the plot axes, below.
+``fill``, ``contour``, ``points``
+  The plot's layers, below; each is optional.
+
+Axes: ``coords`` / ``new_coords``
+==================================
+
+Both take ``x`` and ``y`` entries, each with a ``dimension`` (the dataset variable to put on
+that axis), a ``label`` and optionally ``units``. The ``label`` is used verbatim as the axis
+label, so write the units into it yourself (e.g. ``"$<T_e>$ [$keV$]"``).
+
+``coords`` plots against existing dimensions of the dataset. ``new_coords`` instead remaps the
+field onto *computed* variables (e.g. ``P_auxiliary_launched``) by interpolation; each entry
+additionally accepts ``min``, ``max`` and ``resolution`` for the new axis, and ``new_coords``
+itself accepts ``max_distance``, the (grid-normalised) distance beyond which points too far
+from any sample are masked.
+
+``fill``
+====================
+
+A single filled (colormapped) variable:
+
+``variable``
+  The dataset variable to fill with.
+``units``
+  Units to convert to before plotting; defaults to the variable's own.
+``cbar_label``
+  Colorbar label; defaults to the variable name. The variable's units are appended
+  automatically, so a label which already ends in units renders them twice — write
+  ``cbar_label: "$P_{fusion}$"``, not ``"$P_{fusion}$ [MW]"``.
+``labelpad``
+  Padding of the colorbar label; defaults to ``15.0``.
+``where``
+  A mask, below.
+
+``contour``
+====================
+
+A mapping of dataset variable to contour settings:
+
+``label``
+  Legend entry, used verbatim (units are *not* appended, unlike ``cbar_label``).
+``levels``
+  List of contour levels, in ``units``.
+``color``
+  A matplotlib color.
+``line``
+  Line style; defaults to ``solid``.
+``format``
+  Format spec for the in-line contour labels; ``fontsize`` sets their size (default ``10.0``).
+``units``, ``where``
+  As for ``fill``.
+
+``points``
+====================
+
+A mapping of point name — matching a point in the input file's ``points`` section — to marker
+style: ``label`` (defaults to the point name), ``marker``, ``color`` and ``size``.
+
+``where``
+====================
+
+A mapping of dataset variable to ``min`` / ``max`` bounds (with optional ``units``), hiding the
+regions outside every bound — used to mask the inaccessible parts of the operational space:
+
+.. code::
+
+  where:
+    greenwald_fraction:
+      max: 0.9
+    P_auxiliary_launched:
+      min: 0.0
+      max: 25.0
+      units: MW

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,7 @@ If you are interested in how to setup a development environment to make changes 
   :maxdepth: 1
 
   doc_sources/Usage
+  doc_sources/plot_styles
   doc_sources/physics_glossary
   doc_sources/dev_guide
   doc_sources/api

--- a/example_cases/SPARC_PRD/plot_popcon.yaml
+++ b/example_cases/SPARC_PRD/plot_popcon.yaml
@@ -16,6 +16,7 @@ coords:
 
 fill:
   variable: Q
+  # The variable's units are appended to cbar_label automatically: don't write them in.
   cbar_label: Q
   where:
       Q:

--- a/tests/regression_results/AUG_SepOS_minTe.json
+++ b/tests/regression_results/AUG_SepOS_minTe.json
@@ -150,7 +150,7 @@
             "attrs": {
                 "units": "ampere"
             },
-            "data": 800000.,
+            "data": 800000.0,
             "dims": []
         },
         "poloidal_sound_larmor_radius": {

--- a/tests/regression_results/PRD.json
+++ b/tests/regression_results/PRD.json
@@ -254,7 +254,7 @@
             "attrs": {
                 "units": "pascal"
             },
-            "data": 732029.,
+            "data": 732029.0,
             "dims": []
         },
         "beta_poloidal": {

--- a/tests/test_file_io.py
+++ b/tests/test_file_io.py
@@ -1,0 +1,13 @@
+"""Tests for the JSON point-file formatting."""
+
+import json
+
+from cfspopcon.file_io import _ModifyJSONFloatRepr
+
+
+def test_rounded_floats_remain_valid_json():
+    """A float whose 6-figure form would end in a bare trailing point gains a digit instead."""
+    values = [732029.47, 100000.0, 1.0, 0.123456789, 1234567.0, -732029.47]
+    with _ModifyJSONFloatRepr():
+        text = json.dumps(values)
+    assert json.loads(text) == [732029.5, 100000.0, 1.0, 0.123457, 1.23457e06, -732029.5]

--- a/tests/test_infra/test_plotting.py
+++ b/tests/test_infra/test_plotting.py
@@ -21,6 +21,17 @@ def test_coordinate_formatter(z):
     assert np.isclose(float(z_string.split("=")[1]), x_test + y_test, atol=0.01)
 
 
+def test_coordinate_formatter_with_units(z):
+    # A unitful field must not crash the readout, and should show its units.
+    formatter = plotting.CoordinateFormatter(z.pint.quantify(ureg.MW))
+
+    ret_string = formatter(1.23, -3.45)
+
+    assert ret_string.endswith("[MW]")
+    z_string = ret_string.split(",")[2]
+    assert np.isclose(float(z_string.split("=")[1].removesuffix("[MW]")), 1.23 - 3.45, atol=0.01)
+
+
 @pytest.mark.filterwarnings("error")
 def test_label_contour(z):
     # Make sure that the label contour functionality runs through.


### PR DESCRIPTION
Three independent fixes off `main`, found while verifying a plugin's outputs against the #153 → #155 stack (none is caused by that stack; all are pre-existing).

1. **Point files are now valid JSON.** `_RoundingFloat` formatted floats with `f"{x:#.6g}"`; the `#` alternate form suppresses trailing-zero removal, so a float whose integer part uses all six significant figures was written as `732029.` — rejected by `json.load`. Both committed point files were affected; nothing in the repo reads them back, which is why it survived. Such values now get one extra significant figure (`732029.5` — `#.6g` ends in `.` exactly when the integer part has six digits, and at `#.7g` that case always gains a digit after the point). The regenerated reference files differ by exactly the two broken lines. Known limitation, deliberately unchanged: bare `NaN` tokens remain (Python's `json` accepts them; `allow_nan=False` would instead crash writes on real NaN data).

2. **Interactive popcon plots no longer crash on mouse-over for unitful fill variables.** `CoordinateFormatter` called `float()` on `array.sel(...).item()`, which is a pint `Quantity` for any quantified field — a `DimensionalityError` on every mouse move under `--show`. Invisible until now because both example plot styles fill with dimensionless `Q` and the only test used an unquantified array. The array is dequantified on construction and the readout now shows the units (`z=1.23 [MW]`); tested with a quantified array.

3. **New docs page `plot_styles.rst`**, a reference for the plot-style yaml keys — previously undocumented beyond incidental notebook usage. Notably: the fill variable's units are appended to `cbar_label` automatically, so a label which already contains units renders them twice, while contour and axis labels are used verbatim. A pointer comment now sits next to `cbar_label` in the example style file.

Gates: bare `pytest -q` **156 passed** (includes the doc notebooks); `regression_results.py` then `pytest tests/test_regression_against_cases.py` clean; `ruff check`/`ruff format --check` clean; `mypy cfspopcon` at the 58-errors-in-5-files baseline; `variable_consistency_checker.py` exit 0; docs `-n -W`, doctest and linkcheck clean.
